### PR TITLE
Add a "Configurations" page as an index in the "Develop" section of the sidebar navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -93,18 +93,12 @@ versions:
     children:
       - title: "Add ScalarDB to your build"
         url: /docs/latest/add-scalardb-to-your-build/
-      - title: "ScalarDB Configurations"
-        url: /docs/latest/configurations/
-      - title: "Configurations for Consensus Commit"
-        url: /docs/latest/configurations-for-consensus-commit/
       - title: "ScalarDB Java API Guide"
         url: /docs/latest/api-guide/
+      - title: "Configuration Guides for ScalarDB"
+        url: /docs/latest/development-configurations/
       - title: "ScalarDB Schema Loader"
         url: /docs/latest/schema-loader/
-      - title: "Multi-storage Transactions"
-        url: /docs/latest/multi-storage-transactions/
-      - title: "Two-Phase Commit Transactions"
-        url: /docs/latest/two-phase-commit-transactions/
   # Deploy docs
   - title: "Deploy"
     children:
@@ -172,16 +166,12 @@ versions:
     children:
       - title: "Add ScalarDB to your build"
         url: /docs/3.8/add-scalardb-to-your-build/
-      - title: "Configurations for Consensus Commit"
-        url: /docs/3.8/configurations-for-consensus-commit/
       - title: "ScalarDB Java API Guide"
         url: /docs/3.8/api-guide/
+      - title: "Configuration Guides for ScalarDB"
+        url: /docs/3.8/development-configurations/
       - title: "ScalarDB Schema Loader"
         url: /docs/3.8/schema-loader/
-      - title: "Multi-storage Transactions"
-        url: /docs/3.8/multi-storage-transactions/
-      - title: "Two-Phase Commit Transactions"
-        url: /docs/3.8/two-phase-commit-transactions/
   # Deploy docs
   - title: "Deploy"
     children:
@@ -249,14 +239,10 @@ versions:
     children:
       - title: "Add ScalarDB to your build"
         url: /docs/3.7/add-scalardb-to-your-build/
-      - title: "Configurations for Consensus Commit"
-        url: /docs/3.7/configurations-for-consensus-commit/
       - title: "ScalarDB Java API Guide"
         url: /docs/3.7/api-guide/
-      - title: "Multi-storage Transactions"
-        url: /docs/3.7/multi-storage-transactions/
-      - title: "Two-Phase Commit Transactions"
-        url: /docs/3.7/two-phase-commit-transactions/
+      - title: "Configuration Guides for ScalarDB"
+        url: /docs/3.7/development-configurations/
   # Deploy docs
   - title: "Deploy"
     children:
@@ -324,14 +310,10 @@ versions:
     children:
       - title: "Add ScalarDB to your build"
         url: /docs/3.6/add-scalardb-to-your-build/
-      - title: "Configurations for Consensus Commit"
-        url: /docs/3.6/configurations-for-consensus-commit/
       - title: "ScalarDB Java API Guide"
         url: /docs/3.6/api-guide/
-      - title: "Multi-storage Transactions"
-        url: /docs/3.6/multi-storage-transactions/
-      - title: "Two-Phase Commit Transactions"
-        url: /docs/3.6/two-phase-commit-transactions/
+      - title: "Configuration Guides for ScalarDB"
+        url: /docs/3.6/development-configurations/
   # Deploy docs
   - title: "Deploy"
     children:
@@ -399,10 +381,8 @@ versions:
     children:
       - title: "Add ScalarDB to your build"
         url: /docs/3.5/add-scalardb-to-your-build/
-      - title: "Multi-storage Transactions"
-        url: /docs/3.5/multi-storage-transactions/
-      - title: "Two-Phase Commit Transactions"
-        url: /docs/3.5/two-phase-commit-transactions/
+      - title: "Configuration Guides for ScalarDB"
+        url: /docs/3.5/development-configurations/
   # Deploy docs
   - title: "Deploy"
     children:
@@ -468,10 +448,8 @@ versions:
     children:
       - title: "Add ScalarDB to your build"
         url: /docs/3.4/add-scalardb-to-your-build/
-      - title: "Multi-storage Transactions"
-        url: /docs/3.4/multi-storage-transactions/
-      - title: "Two-Phase Commit Transactions"
-        url: /docs/3.4/two-phase-commit-transactions/
+      - title: "Configuration Guides for ScalarDB"
+        url: /docs/3.4/development-configurations/
   # Deploy docs
   - title: "Deploy"
     children:

--- a/docs/3.4/development-configurations.md
+++ b/docs/3.4/development-configurations.md
@@ -1,0 +1,6 @@
+# Configuration Guides for ScalarDB
+
+The following is a list of configuration guides for ScalarDB:
+
+- [Configure Multi-Storage Transactions](multi-storage-transactions.md)
+- [Configure Two-Phase Commit Transactions](two-phase-commit-transactions.md)

--- a/docs/3.5/development-configurations.md
+++ b/docs/3.5/development-configurations.md
@@ -1,0 +1,6 @@
+# Configuration Guides for ScalarDB
+
+The following is a list of configuration guides for ScalarDB:
+
+- [Configure Multi-Storage Transactions](multi-storage-transactions.md)
+- [Configure Two-Phase Commit Transactions](two-phase-commit-transactions.md)

--- a/docs/3.6/development-configurations.md
+++ b/docs/3.6/development-configurations.md
@@ -1,0 +1,7 @@
+# Configuration Guides for ScalarDB
+
+The following is a list of configuration guides for ScalarDB:
+
+- [Configure Consensus Commit](configurations-for-consensus-commit.md)
+- [Configure Multi-Storage Transactions](multi-storage-transactions.md)
+- [Configure Two-Phase Commit Transactions](two-phase-commit-transactions.md)

--- a/docs/3.7/development-configurations.md
+++ b/docs/3.7/development-configurations.md
@@ -1,0 +1,7 @@
+# Configuration Guides for ScalarDB
+
+The following is a list of configuration guides for ScalarDB:
+
+- [Configure Consensus Commit](configurations-for-consensus-commit.md)
+- [Configure Multi-Storage Transactions](multi-storage-transactions.md)
+- [Configure Two-Phase Commit Transactions](two-phase-commit-transactions.md)

--- a/docs/3.8/development-configurations.md
+++ b/docs/3.8/development-configurations.md
@@ -1,0 +1,7 @@
+# Configuration Guides for ScalarDB
+
+The following is a list of configuration guides for ScalarDB:
+
+- [Configure Consensus Commit](configurations-for-consensus-commit.md)
+- [Configure Multi-Storage Transactions](multi-storage-transactions.md)
+- [Configure Two-Phase Commit Transactions](two-phase-commit-transactions.md)

--- a/docs/3.9/development-configurations.md
+++ b/docs/3.9/development-configurations.md
@@ -1,0 +1,8 @@
+# Configuration Guides for ScalarDB
+
+The following is a list of configuration guides for ScalarDB:
+
+- [Configure ScalarDB](configurations.md)
+- [Configure Consensus Commit](configurations-for-consensus-commit.md)
+- [Configure Multi-Storage Transactions](multi-storage-transactions.md)
+- [Configure Two-Phase Commit Transactions](two-phase-commit-transactions.md)

--- a/docs/latest/development-configurations.md
+++ b/docs/latest/development-configurations.md
@@ -1,0 +1,8 @@
+# Configuration Guides for ScalarDB
+
+The following is a list of configuration guides for ScalarDB:
+
+- [Configure ScalarDB](configurations.md)
+- [Configure Consensus Commit](configurations-for-consensus-commit.md)
+- [Configure Multi-Storage Transactions](multi-storage-transactions.md)
+- [Configure Two-Phase Commit Transactions](two-phase-commit-transactions.md)


### PR DESCRIPTION
## Description

This PR adds a new "Configuration" page that acts as an index for configuration-related docs that live in the "Develop" section of the side navigation and updates the navigation to add the new page and remove the pages listed in that index.

### Related issue or PR

N/A

### Type of change

- [x] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, checked the side navigation for each version, and checked the new "configuration" pages that contain a list of configuration-related doc types displayed and were navigable as expected.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have conducted tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.
