### PR TITLE
Add instructions to clone the ScalarDB samples repository

### DIFF
--- a/docs/3.4/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.4/scalardb-samples/microservice-transaction-sample/README.md
@@ -164,6 +164,20 @@ And the `repayment` endpoint of Customer Service is for transaction #5.
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/microservice-transaction-sample
+```
+
 ### Start Cassandra and MySQL
 
 To start Cassandra and MySQL, you need to run the following `docker-compose` command:

--- a/docs/3.4/scalardb-samples/multi-storage-transaction-sample/README.md
+++ b/docs/3.4/scalardb-samples/multi-storage-transaction-sample/README.md
@@ -136,6 +136,20 @@ For details, please see [Configuration - Multi-storage Transactions](https://git
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/multi-storage-transaction-sample
+```
+
 ### Start Cassandra and MySQL
 
 To start Cassandra and MySQL, you need to run the following `docker-compose` command:

--- a/docs/3.4/scalardb-samples/scalardb-sample/README.md
+++ b/docs/3.4/scalardb-samples/scalardb-sample/README.md
@@ -119,6 +119,20 @@ Since this sample application uses Cassandra, as shown above, you need to config
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/scalardb-sample
+```
+
 ### Start Cassandra
 
 To start Cassandra, you need to run the following `docker-compose` command:

--- a/docs/3.4/scalardb-samples/scalardb-server-sample/README.md
+++ b/docs/3.4/scalardb-samples/scalardb-server-sample/README.md
@@ -33,6 +33,22 @@ scalar.db.password=cassandra
 scalar.db.storage=cassandra
 ```
 
+#### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/scalardb-server-sample
+```
+
+#### Start Cassandra
+
 To start Cassandra and ScalarDB Server, we use the following command.
 Please note that we should wait around a bit more than one minute because ScalarDB container has to wait for Cassandra container to be fully started.
 ```shell

--- a/docs/3.5/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.5/scalardb-samples/microservice-transaction-sample/README.md
@@ -164,6 +164,20 @@ And the `repayment` endpoint of Customer Service is for transaction #5.
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/microservice-transaction-sample
+```
+
 ### Start Cassandra and MySQL
 
 To start Cassandra and MySQL, you need to run the following `docker-compose` command:

--- a/docs/3.5/scalardb-samples/multi-storage-transaction-sample/README.md
+++ b/docs/3.5/scalardb-samples/multi-storage-transaction-sample/README.md
@@ -136,6 +136,20 @@ For details, please see [Configuration - Multi-storage Transactions](https://git
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/multi-storage-transaction-sample
+```
+
 ### Start Cassandra and MySQL
 
 To start Cassandra and MySQL, you need to run the following `docker-compose` command:

--- a/docs/3.5/scalardb-samples/scalardb-sample/README.md
+++ b/docs/3.5/scalardb-samples/scalardb-sample/README.md
@@ -119,6 +119,20 @@ Since this sample application uses Cassandra, as shown above, you need to config
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/scalardb-sample
+```
+
 ### Start Cassandra
 
 To start Cassandra, you need to run the following `docker-compose` command:

--- a/docs/3.5/scalardb-samples/scalardb-server-sample/README.md
+++ b/docs/3.5/scalardb-samples/scalardb-server-sample/README.md
@@ -33,6 +33,22 @@ scalar.db.password=cassandra
 scalar.db.storage=cassandra
 ```
 
+#### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/scalardb-server-sample
+```
+
+#### Start Cassandra
+
 To start Cassandra and ScalarDB Server, we use the following command.
 Please note that we should wait around a bit more than one minute because ScalarDB container has to wait for Cassandra container to be fully started.
 ```shell

--- a/docs/3.6/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.6/scalardb-samples/microservice-transaction-sample/README.md
@@ -164,6 +164,20 @@ And the `repayment` endpoint of Customer Service is for transaction #5.
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/microservice-transaction-sample
+```
+
 ### Start Cassandra and MySQL
 
 To start Cassandra and MySQL, you need to run the following `docker-compose` command:

--- a/docs/3.6/scalardb-samples/multi-storage-transaction-sample/README.md
+++ b/docs/3.6/scalardb-samples/multi-storage-transaction-sample/README.md
@@ -136,6 +136,20 @@ For details, please see [Configuration - Multi-storage Transactions](https://git
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/multi-storage-transaction-sample
+```
+
 ### Start Cassandra and MySQL
 
 To start Cassandra and MySQL, you need to run the following `docker-compose` command:

--- a/docs/3.6/scalardb-samples/scalardb-sample/README.md
+++ b/docs/3.6/scalardb-samples/scalardb-sample/README.md
@@ -119,6 +119,20 @@ Since this sample application uses Cassandra, as shown above, you need to config
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/scalardb-sample
+```
+
 ### Start Cassandra
 
 To start Cassandra, you need to run the following `docker-compose` command:

--- a/docs/3.6/scalardb-samples/scalardb-server-sample/README.md
+++ b/docs/3.6/scalardb-samples/scalardb-server-sample/README.md
@@ -33,6 +33,22 @@ scalar.db.password=cassandra
 scalar.db.storage=cassandra
 ```
 
+#### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/scalardb-server-sample
+```
+
+#### Start Cassandra
+
 To start Cassandra and ScalarDB Server, we use the following command.
 Please note that we should wait around a bit more than one minute because ScalarDB container has to wait for Cassandra container to be fully started.
 ```shell

--- a/docs/3.7/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.7/scalardb-samples/microservice-transaction-sample/README.md
@@ -164,6 +164,20 @@ And the `repayment` endpoint of Customer Service is for transaction #5.
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/microservice-transaction-sample
+```
+
 ### Start Cassandra and MySQL
 
 To start Cassandra and MySQL, you need to run the following `docker-compose` command:

--- a/docs/3.7/scalardb-samples/multi-storage-transaction-sample/README.md
+++ b/docs/3.7/scalardb-samples/multi-storage-transaction-sample/README.md
@@ -136,6 +136,20 @@ For details, please see [Configuration - Multi-storage Transactions](https://git
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/multi-storage-transaction-sample
+```
+
 ### Start Cassandra and MySQL
 
 To start Cassandra and MySQL, you need to run the following `docker-compose` command:

--- a/docs/3.7/scalardb-samples/scalardb-sample/README.md
+++ b/docs/3.7/scalardb-samples/scalardb-sample/README.md
@@ -119,6 +119,20 @@ Since this sample application uses Cassandra, as shown above, you need to config
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/scalardb-sample
+```
+
 ### Start Cassandra
 
 To start Cassandra, you need to run the following `docker-compose` command:

--- a/docs/3.7/scalardb-samples/scalardb-server-sample/README.md
+++ b/docs/3.7/scalardb-samples/scalardb-server-sample/README.md
@@ -33,6 +33,22 @@ scalar.db.password=cassandra
 scalar.db.storage=cassandra
 ```
 
+#### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/scalardb-server-sample
+```
+
+#### Start Cassandra
+
 To start Cassandra and ScalarDB Server, we use the following command.
 Please note that we should wait around a bit more than one minute because ScalarDB container has to wait for Cassandra container to be fully started.
 ```shell

--- a/docs/3.8/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.8/scalardb-samples/microservice-transaction-sample/README.md
@@ -164,6 +164,20 @@ And the `repayment` endpoint of Customer Service is for transaction #5.
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/microservice-transaction-sample
+```
+
 ### Start Cassandra and MySQL
 
 To start Cassandra and MySQL, you need to run the following `docker-compose` command:

--- a/docs/3.8/scalardb-samples/multi-storage-transaction-sample/README.md
+++ b/docs/3.8/scalardb-samples/multi-storage-transaction-sample/README.md
@@ -136,6 +136,20 @@ For details, please see [Configuration - Multi-storage Transactions](https://git
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/multi-storage-transaction-sample
+```
+
 ### Start Cassandra and MySQL
 
 To start Cassandra and MySQL, you need to run the following `docker-compose` command:

--- a/docs/3.8/scalardb-samples/scalardb-sample/README.md
+++ b/docs/3.8/scalardb-samples/scalardb-sample/README.md
@@ -119,6 +119,20 @@ Since this sample application uses Cassandra, as shown above, you need to config
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/scalardb-sample
+```
+
 ### Start Cassandra
 
 To start Cassandra, you need to run the following `docker-compose` command:

--- a/docs/3.8/scalardb-samples/scalardb-server-sample/README.md
+++ b/docs/3.8/scalardb-samples/scalardb-server-sample/README.md
@@ -33,6 +33,22 @@ scalar.db.password=cassandra
 scalar.db.storage=cassandra
 ```
 
+#### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/scalardb-server-sample
+```
+
+#### Start Cassandra
+
 To start Cassandra and ScalarDB Server, we use the following command.
 Please note that we should wait around a bit more than one minute because ScalarDB container has to wait for Cassandra container to be fully started.
 ```shell

--- a/docs/3.9/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.9/scalardb-samples/microservice-transaction-sample/README.md
@@ -164,6 +164,20 @@ And the `repayment` endpoint of Customer Service is for transaction #5.
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/microservice-transaction-sample
+```
+
 ### Start Cassandra and MySQL
 
 To start Cassandra and MySQL, you need to run the following `docker-compose` command:

--- a/docs/3.9/scalardb-samples/multi-storage-transaction-sample/README.md
+++ b/docs/3.9/scalardb-samples/multi-storage-transaction-sample/README.md
@@ -136,6 +136,20 @@ For details, please see [Configuration - Multi-storage Transactions](https://git
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/multi-storage-transaction-sample
+```
+
 ### Start Cassandra and MySQL
 
 To start Cassandra and MySQL, you need to run the following `docker-compose` command:

--- a/docs/3.9/scalardb-samples/scalardb-sample/README.md
+++ b/docs/3.9/scalardb-samples/scalardb-sample/README.md
@@ -119,6 +119,20 @@ Since this sample application uses Cassandra, as shown above, you need to config
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/scalardb-sample
+```
+
 ### Start Cassandra
 
 To start Cassandra, you need to run the following `docker-compose` command:

--- a/docs/latest/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/latest/scalardb-samples/microservice-transaction-sample/README.md
@@ -164,6 +164,20 @@ And the `repayment` endpoint of Customer Service is for transaction #5.
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/microservice-transaction-sample
+```
+
 ### Start Cassandra and MySQL
 
 To start Cassandra and MySQL, you need to run the following `docker-compose` command:

--- a/docs/latest/scalardb-samples/multi-storage-transaction-sample/README.md
+++ b/docs/latest/scalardb-samples/multi-storage-transaction-sample/README.md
@@ -136,6 +136,20 @@ For details, please see [Configuration - Multi-storage Transactions](https://git
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/multi-storage-transaction-sample
+```
+
 ### Start Cassandra and MySQL
 
 To start Cassandra and MySQL, you need to run the following `docker-compose` command:

--- a/docs/latest/scalardb-samples/scalardb-sample/README.md
+++ b/docs/latest/scalardb-samples/scalardb-sample/README.md
@@ -119,6 +119,20 @@ Since this sample application uses Cassandra, as shown above, you need to config
 
 ## Setup
 
+### Clone the ScalarDB samples repository
+
+Open Terminal, then clone the ScalarDB samples repository by running the following command:
+
+```shell
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory with this sample by running the following command:
+
+```shell
+$ cd scalardb-samples/scalardb-sample
+```
+
 ### Start Cassandra
 
 To start Cassandra, you need to run the following `docker-compose` command:


### PR DESCRIPTION
## Description

This PR adds instructions to clone the [`scalardb-samples`](https://github.com/scalar-labs/scalardb-samples) repository.

> **Note**
> 
> This revision is a quick fix only in this repository. We will be doing a comprehensive revising and reorganizing of the original docs in the [`scalardb-samples`](https://github.com/scalar-labs/scalardb-samples) repository in the near future.

### Related issue or PR

N/A

### Type of change

- [x] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, checked the samples pages across versions, and confirmed that the instructions for cloning the repository and going into the folder appeared on pages across versions.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have conducted tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.
