### PR TITLE
Add redirects for deleted "getting started" docs

### DIFF
--- a/docs/3.10/redirect-getting-started.md
+++ b/docs/3.10/redirect-getting-started.md
@@ -1,0 +1,11 @@
+---
+redirect_from: 
+  - /docs/3.10/getting-started/
+  - /docs/3.10/getting-started-with-scalardb-on-cassandra/
+  - /docs/3.10/getting-started-with-scalardb-on-cosmosdb/
+  - /docs/3.10/getting-started-with-scalardb-on-dynamodb/
+  - /docs/3.10/getting-started-with-scalardb-on-jdbc/
+---
+
+<!-- Redirect implemented on August 17, 2023; may be deprecated if analytics shows no visitors over a long period. -->
+<meta http-equiv="Refresh" content="0; url='/docs/3.10/getting-started-with-scalardb/'" />

--- a/docs/3.5/redirect-getting-started.md
+++ b/docs/3.5/redirect-getting-started.md
@@ -1,0 +1,11 @@
+---
+redirect_from: 
+  - /docs/3.5/getting-started/
+  - /docs/3.5/getting-started-with-scalardb-on-cassandra/
+  - /docs/3.5/getting-started-with-scalardb-on-cosmosdb/
+  - /docs/3.5/getting-started-with-scalardb-on-dynamodb/
+  - /docs/3.5/getting-started-with-scalardb-on-jdbc/
+---
+
+<!-- Redirect implemented on August 17, 2023; may be deprecated if analytics shows no visitors over a long period. -->
+<meta http-equiv="Refresh" content="0; url='/docs/3.5/getting-started-with-scalardb/'" />

--- a/docs/3.6/redirect-getting-started.md
+++ b/docs/3.6/redirect-getting-started.md
@@ -1,0 +1,11 @@
+---
+redirect_from: 
+  - /docs/3.6/getting-started/
+  - /docs/3.6/getting-started-with-scalardb-on-cassandra/
+  - /docs/3.6/getting-started-with-scalardb-on-cosmosdb/
+  - /docs/3.6/getting-started-with-scalardb-on-dynamodb/
+  - /docs/3.6/getting-started-with-scalardb-on-jdbc/
+---
+
+<!-- Redirect implemented on August 17, 2023; may be deprecated if analytics shows no visitors over a long period. -->
+<meta http-equiv="Refresh" content="0; url='/docs/3.6/getting-started-with-scalardb/'" />

--- a/docs/3.7/redirect-getting-started.md
+++ b/docs/3.7/redirect-getting-started.md
@@ -1,0 +1,11 @@
+---
+redirect_from: 
+  - /docs/3.7/getting-started/
+  - /docs/3.7/getting-started-with-scalardb-on-cassandra/
+  - /docs/3.7/getting-started-with-scalardb-on-cosmosdb/
+  - /docs/3.7/getting-started-with-scalardb-on-dynamodb/
+  - /docs/3.7/getting-started-with-scalardb-on-jdbc/
+---
+
+<!-- Redirect implemented on August 17, 2023; may be deprecated if analytics shows no visitors over a long period. -->
+<meta http-equiv="Refresh" content="0; url='/docs/3.7/getting-started-with-scalardb/'" />

--- a/docs/3.8/redirect-getting-started.md
+++ b/docs/3.8/redirect-getting-started.md
@@ -1,0 +1,11 @@
+---
+redirect_from: 
+  - /docs/3.8/getting-started/
+  - /docs/3.8/getting-started-with-scalardb-on-cassandra/
+  - /docs/3.8/getting-started-with-scalardb-on-cosmosdb/
+  - /docs/3.8/getting-started-with-scalardb-on-dynamodb/
+  - /docs/3.8/getting-started-with-scalardb-on-jdbc/
+---
+
+<!-- Redirect implemented on August 17, 2023; may be deprecated if analytics shows no visitors over a long period. -->
+<meta http-equiv="Refresh" content="0; url='/docs/3.8/getting-started-with-scalardb/'" />

--- a/docs/3.9/redirect-getting-started.md
+++ b/docs/3.9/redirect-getting-started.md
@@ -1,0 +1,11 @@
+---
+redirect_from: 
+  - /docs/3.9/getting-started/
+  - /docs/3.9/getting-started-with-scalardb-on-cassandra/
+  - /docs/3.9/getting-started-with-scalardb-on-cosmosdb/
+  - /docs/3.9/getting-started-with-scalardb-on-dynamodb/
+  - /docs/3.9/getting-started-with-scalardb-on-jdbc/
+---
+
+<!-- Redirect implemented on August 17, 2023; may be deprecated if analytics shows no visitors over a long period. -->
+<meta http-equiv="Refresh" content="0; url='/docs/3.9/getting-started-with-scalardb/'" />

--- a/docs/latest/redirect-getting-started.md
+++ b/docs/latest/redirect-getting-started.md
@@ -1,0 +1,11 @@
+---
+redirect_from: 
+  - /docs/latest/getting-started/
+  - /docs/latest/getting-started-with-scalardb-on-cassandra/
+  - /docs/latest/getting-started-with-scalardb-on-cosmosdb/
+  - /docs/latest/getting-started-with-scalardb-on-dynamodb/
+  - /docs/latest/getting-started-with-scalardb-on-jdbc/
+---
+
+<!-- Redirect implemented on August 17, 2023; may be deprecated if analytics shows no visitors over a long period. -->
+<meta http-equiv="Refresh" content="0; url='/docs/latest/getting-started-with-scalardb/'" />


### PR DESCRIPTION
## Description

This PR adds redirects for "getting started" docs that we deleted when we reorganized the multiple "getting started" docs into a single doc. Now, when a visitor goes to the URLs of the deleted pages, they are redirected to `getting-started-with-scalardb` (for example, [`getting-started-with-scalardb`](https://scalardb-community.scalar-labs.com/docs/latest/getting-started-with-scalardb/)). This change applies to the docs of currently supported versions (3.5 - 3.10).

### Related issue or PR

- https://github.com/scalar-labs/docs-scalardb-community/pull/39

### Type of change

- [ ] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [x] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, and confirmed that the redirects worked as expected for the pages and their versions.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have conducted tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.
