### PR TITLE
Change link for "Getting Started with ScalarDB"

### DIFF
--- a/docs/3.5/scalardb-samples/scalardb-server-sample/README.md
+++ b/docs/3.5/scalardb-samples/scalardb-server-sample/README.md
@@ -1,6 +1,6 @@
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
-For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md).
+For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
 More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.md).
 
 ## Sample application
@@ -54,7 +54,7 @@ Please note that we should wait around a bit more than one minute because Scalar
 ```shell
 $ docker-compose -f docker-compose-cassandra.yml up -d
 ```
-*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
+*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
 
 ### ScalarDB client
 The sample application uses a client that implements ScalarDB interface.

--- a/docs/3.6/scalardb-samples/scalardb-server-sample/README.md
+++ b/docs/3.6/scalardb-samples/scalardb-server-sample/README.md
@@ -1,6 +1,6 @@
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
-For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md).
+For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
 More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.md).
 
 ## Sample application
@@ -54,7 +54,7 @@ Please note that we should wait around a bit more than one minute because Scalar
 ```shell
 $ docker-compose -f docker-compose-cassandra.yml up -d
 ```
-*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
+*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
 
 ### ScalarDB client
 The sample application uses a client that implements ScalarDB interface.

--- a/docs/3.7/scalardb-samples/scalardb-server-sample/README.md
+++ b/docs/3.7/scalardb-samples/scalardb-server-sample/README.md
@@ -1,6 +1,6 @@
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
-For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md).
+For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
 More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.md).
 
 ## Sample application
@@ -54,7 +54,7 @@ Please note that we should wait around a bit more than one minute because Scalar
 ```shell
 $ docker-compose -f docker-compose-cassandra.yml up -d
 ```
-*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
+*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
 
 ### ScalarDB client
 The sample application uses a client that implements ScalarDB interface.

--- a/docs/3.8/scalardb-samples/scalardb-server-sample/README.md
+++ b/docs/3.8/scalardb-samples/scalardb-server-sample/README.md
@@ -1,6 +1,6 @@
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
-For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md).
+For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
 More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.md).
 
 ## Sample application
@@ -54,7 +54,7 @@ Please note that we should wait around a bit more than one minute because Scalar
 ```shell
 $ docker-compose -f docker-compose-cassandra.yml up -d
 ```
-*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
+*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
 
 ### ScalarDB client
 The sample application uses a client that implements ScalarDB interface.


### PR DESCRIPTION
## Description

This PR updates the link for the "Getting Started with ScalarDB" doc in other docs. (This is an interim fix until all PRs in source code repositories are merged.) 

### Related issue or PR

- https://github.com/scalar-labs/scalardb/pull/990

### Type of change

- [x] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, and confirmed that the updated links worked as expected.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have conducted tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.
