### PR TITLE
Add out-of-support banner for ScalarDB 3.4

### DIFF
--- a/_includes/end-of-support.html
+++ b/_includes/end-of-support.html
@@ -1,7 +1,7 @@
 {% capture notice-2 %}
 **Warning**
 
-This version of ScalarDB is no longer supported. We recommend that you update to the [latest version](/docs/latest/) of ScalarDB.
+This version of ScalarDB is no longer supported. We recommend that you update to the [latest version](/docs/latest/getting-started-with-scalardb/) of ScalarDB.
 {% endcapture %}
 
 <div class="notice--danger">{{ notice-2 | markdownify }}</div>

--- a/docs/3.4/add-scalardb-to-your-build.md
+++ b/docs/3.4/add-scalardb-to-your-build.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Add ScalarDB to your build
 
 The library is available on [maven central repository](https://mvnrepository.com/artifact/com.scalar-labs/scalardb).

--- a/docs/3.4/backup-restore.md
+++ b/docs/3.4/backup-restore.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # A Guide on How to Back up and Restore Databases Integrated with Scalar DB
 
 Since Scalar DB provides transaction capability on top of non-transactional (possibly transactional) databases non-invasively, you need to take special care of backing up and restoring the databases in a transactionally-consistent way.

--- a/docs/3.4/development-configurations.md
+++ b/docs/3.4/development-configurations.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Configuration Guides for ScalarDB
 
 The following is a list of configuration guides for ScalarDB:

--- a/docs/3.4/getting-started-with-scalardb-on-cassandra.md
+++ b/docs/3.4/getting-started-with-scalardb-on-cassandra.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar DB on Cassandra
     
 ## Overview

--- a/docs/3.4/getting-started-with-scalardb-on-cosmosdb.md
+++ b/docs/3.4/getting-started-with-scalardb-on-cosmosdb.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar DB on Cosmos DB
 
 ## Overview

--- a/docs/3.4/getting-started-with-scalardb-on-dynamodb.md
+++ b/docs/3.4/getting-started-with-scalardb-on-dynamodb.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar DB on DynamoDB
 
 ## Overview

--- a/docs/3.4/getting-started-with-scalardb-on-jdbc.md
+++ b/docs/3.4/getting-started-with-scalardb-on-jdbc.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar DB on JDBC databases
 
 ## Overview

--- a/docs/3.4/getting-started-with-scalardb.md
+++ b/docs/3.4/getting-started-with-scalardb.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar DB
 
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.

--- a/docs/3.4/getting-started.md
+++ b/docs/3.4/getting-started.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar DB
 
 ## Overview

--- a/docs/3.4/index.md
+++ b/docs/3.4/index.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 ## Scalar DB
 
 [![CI](https://github.com/scalar-labs/scalardb/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/scalar-labs/scalardb/actions/workflows/ci.yaml)

--- a/docs/3.4/requirements.md
+++ b/docs/3.4/requirements.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Requirements in the Underlining Databases of Scalar DB
 
 This document explains the requirements in the underlining databases of Scalar DB to make Scalar DB applications work correctly.

--- a/docs/3.4/scalardb-benchmarks/README.md
+++ b/docs/3.4/scalardb-benchmarks/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # ScalarDB Benchmarks
 
 This repository contains benchmark programs for ScalarDB.

--- a/docs/3.4/scalardb-samples/README.md
+++ b/docs/3.4/scalardb-samples/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # ScalarDB Samples
 
 This repository contains sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):

--- a/docs/3.4/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.4/scalardb-samples/microservice-transaction-sample/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Microservice Transaction Sample
 
 This tutorial describes how to create a sample application for Microservice Transaction that uses Two-phase Commit Transactions in ScalarDB.

--- a/docs/3.4/scalardb-samples/multi-storage-transaction-sample/README.md
+++ b/docs/3.4/scalardb-samples/multi-storage-transaction-sample/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Multi-storage Transaction Sample
 
 This tutorial describes how to create a sample application by using ScalarDB with Multi-storage Transactions.

--- a/docs/3.4/scalardb-samples/scalardb-sample/README.md
+++ b/docs/3.4/scalardb-samples/scalardb-sample/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # ScalarDB Sample
 
 This tutorial describes how to create a sample application by using ScalarDB.

--- a/docs/3.4/scalardb-samples/scalardb-server-sample/README.md
+++ b/docs/3.4/scalardb-samples/scalardb-server-sample/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
 For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md).

--- a/docs/3.4/scalardb-server.md
+++ b/docs/3.4/scalardb-server.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Scalar DB server
 
 Scalar DB server is a gRPC server that implements Scalar DB interface. 

--- a/docs/3.4/schema.md
+++ b/docs/3.4/schema.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Database schema in Scalar DB
 
 Scalar DB has its own data model and schema, that maps to the implementation specific data model and schema.

--- a/docs/3.4/two-phase-commit-transactions.md
+++ b/docs/3.4/two-phase-commit-transactions.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Two-phase Commit Transactions
 
 Scalar DB also supports two-phase commit style transactions called *Two-phase Commit Transactions*.


### PR DESCRIPTION
## Description

This PR:

- Adds an out-of-support banner to the top of ScalarDB 3.4 docs.
- Updates the link in the out-of-support banner.

### Related issue or PR

N/A

### Type of change

- [x] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

**Please describe the tests that you ran to verify your changes and provide instructions so that we can reproduce. Please also list any relevant details for your test configuration.**

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, and confirmed that the out-of-support banner appeared as expected on version 3.4 docs only.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
