### PR TITLE
Fix an error when a trailing slash exists in the home page URL

### DIFF
--- a/_home/home.md
+++ b/_home/home.md
@@ -1,6 +1,6 @@
 ---
 layout: parent-product-home
-permalink: /docs
+permalink: /docs/
 hidden: true
 toc: false
 product_row:


### PR DESCRIPTION
## Description

This PR fixes an error when a slash (`/`) exists at the end of the home page. For example:

- **ScalarDB Community home page is displayed:** https://scalardb-community.scalar-labs.com/docs
- **Error page is displayed:** https://scalardb-community.scalar-labs.com/docs/

### Related issue or PR

N/A

### Type of change

- [ ] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [x] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

I was unable to duplicate this error locally, so I can't confirm if this PR fixes the issue until it's deployed through GitHub Pages. I will provide an update after merging this PR and confirming if the home page can be navigated to with or without a trailing slash (`/`).

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have conducted tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.
