### PR TITLE
Make the header/masthead fixed to the top of pages for better navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -194,7 +194,19 @@ defaults:
       toc: true
       toc_sticky: true
       search: true
-
+  # 3.10
+  - scope:
+      path: "docs/3.10" # Specifies the name of the folder where this version of docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "latest" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: false
   # 3.9
   - scope:
       path: "docs/3.9" # Specifies the name of the folder where this version of docs are located.

--- a/_sass/minimal-mistakes/_masthead.scss
+++ b/_sass/minimal-mistakes/_masthead.scss
@@ -3,7 +3,9 @@
    ========================================================================== */
 
    .masthead {
-    position: relative;
+    position: fixed; // Makes the header/masthead fixed to the top of the page when scrolling; originally `position: relative` (modified by josh-wong).
+    background-color: $background-color; // Added so that there's a background (rather than being transparent) below around the header navigation (added by josh-wong).
+    width: 100%; // Added to make the header/masthead extend across the top of the screen (added by josh-wong).
     border-bottom: 1px solid $border-color;
     -webkit-animation: $intro-transition;
     animation: $intro-transition;

--- a/_sass/minimal-mistakes/_page.scss
+++ b/_sass/minimal-mistakes/_page.scss
@@ -13,6 +13,7 @@
   max-width: 100%;
   -webkit-animation-delay: 0.15s;
   animation-delay: 0.15s;
+  padding-top: 4.85em; // Added to shift the body contents and navigation down so that the header/masthead can be fixed while still showing all page contents (added by josh-wong).
 
   @include breakpoint($x-large) {
     max-width: $max-width;

--- a/_sass/minimal-mistakes/_search.scss
+++ b/_sass/minimal-mistakes/_search.scss
@@ -33,7 +33,7 @@
 .search-content {
   display: none;
   visibility: hidden;
-  padding-top: 1em;
+  padding-top: 4.85em; // Modified to shift the body contents and navigation down so that the header/masthead can be fixed while still showing all page contents; originally `padding-top: 1em;` (added by josh-wong).
   padding-bottom: 1em;
 
   &__inner-wrap {

--- a/_sass/minimal-mistakes/_sidebar.scss
+++ b/_sass/minimal-mistakes/_sidebar.scss
@@ -22,6 +22,8 @@
       /* opacity: 0.75; /* Ignoring opacity because it causes opacity to apply to the dropdown menu (modified by josh-wong) */
       -webkit-transition: opacity 0.2s ease-in-out;
       transition: opacity 0.2s ease-in-out;
+      position: sticky; // Added to shift the side navigation down so that the version navigation bar isn't hidden behind the header/masthead when scrolling the main contents of the page (added by josh-wong).
+      top: 4.85em; // Added to shift the side navigation down so that the version navigation bar isn't hidden behind the header/masthead when scrolling the main contents of the page (added by josh-wong).
   
       &:hover {
         opacity: 1;
@@ -250,7 +252,7 @@
         @include clearfix();
         position: -webkit-sticky;
         position: sticky;
-        top: 2em;
+        top: 8.5em; // Modified to shift the TOC sidebar down so that the fixed masthead doesn't cover the TOC sidebar; originally `top: 2em;` (modified by josh-wong).
         float: right;
   
         .toc {


### PR DESCRIPTION
## Description

This PR makes the header/masthead fixed to the top of the page. Keeping the header at the top of pages while scrolling will help readers:

- Navigate to the links in the header without needing to scroll to the top of the page.
- Click the search button without needing to scroll to the top of the page.
- Recognize that they are on a Scalar docs site.

## Related issues and/or PRs

N/A

## Changes made

Made changes to a few CSS files so that:
- The header stays fixed when scrolling on a page.
- The side navigation become hidden behind the header (now that it's in a fixed position) when scrolling.
- The TOC become hidden behind the header (now that it's in a fixed position) when scrolling.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
