### PR TITLE
Add updated doc showing supported databases

### DIFF
--- a/docs/3.7/scalardb-supported-databases.md
+++ b/docs/3.7/scalardb-supported-databases.md
@@ -6,6 +6,7 @@ ScalarDB supports the following databases and their versions.
 
 | Version           | DynamoDB  |
 |:------------------|:----------|
+| **ScalarDB 3.11** | ✅        |
 | **ScalarDB 3.10** | ✅        |
 | **ScalarDB 3.9**  | ✅        |
 | **ScalarDB 3.8**  | ✅        |
@@ -26,6 +27,7 @@ For requirements when using Cassandra or Cassandra-compatible databases, see [Ca
 
 | Version           | Cassandra 4.1  | Cassandra 4.0  | Cassandra 3.11  | Cassandra 3.0  |
 |:------------------|:---------------|:---------------|:----------------|:---------------|
+| **ScalarDB 3.11** | ❌             | ❌             | ✅              | ✅             |
 | **ScalarDB 3.10** | ❌             | ❌             | ✅              | ✅             |
 | **ScalarDB 3.9**  | ❌             | ❌             | ✅              | ✅             |
 | **ScalarDB 3.8**  | ❌             | ❌             | ✅              | ✅             |
@@ -38,6 +40,7 @@ For requirements when using Cassandra or Cassandra-compatible databases, see [Ca
 
 | Version           | Cosmos DB for NoSQL  |
 |:------------------|:---------------------|
+| **ScalarDB 3.11** | ✅                   |
 | **ScalarDB 3.10** | ✅                   |
 | **ScalarDB 3.9**  | ✅                   |
 | **ScalarDB 3.8**  | ✅                   |
@@ -60,6 +63,7 @@ For recommendations when using JDBC databases, see [JDBC database recommendation
 
 | Version           | Aurora MySQL 3  | Aurora MySQL 2  |
 |:------------------|:----------------|:----------------|
+| **ScalarDB 3.11** | ✅              | ✅              |
 | **ScalarDB 3.10** | ✅              | ✅              |
 | **ScalarDB 3.9**  | ✅              | ✅              |
 | **ScalarDB 3.8**  | ✅              | ✅              |
@@ -72,6 +76,7 @@ For recommendations when using JDBC databases, see [JDBC database recommendation
 
 | Version           | Aurora PostgreSQL 15  | Aurora PostgreSQL 14  | Aurora PostgreSQL 13  | Aurora PostgreSQL 12  |
 |:------------------|:----------------------|:----------------------|:----------------------|:----------------------|
+| **ScalarDB 3.11** | ✅                    | ✅                    | ✅                    | ✅                    |
 | **ScalarDB 3.10** | ✅                    | ✅                    | ✅                    | ✅                    |
 | **ScalarDB 3.9**  | ✅                    | ✅                    | ✅                    | ✅                    |
 | **ScalarDB 3.8**  | ✅                    | ✅                    | ✅                    | ✅                    |
@@ -84,6 +89,7 @@ For recommendations when using JDBC databases, see [JDBC database recommendation
 
 | Version           | MariaDB 10.11 |
 |:------------------|:--------------|
+| **ScalarDB 3.11** | ✅            |
 | **ScalarDB 3.10** | ✅            |
 | **ScalarDB 3.9**  | ✅            |
 | **ScalarDB 3.8**  | ✅            |
@@ -96,6 +102,7 @@ For recommendations when using JDBC databases, see [JDBC database recommendation
 
 | Version           | SQL Server 2022  | SQL Server 2019  | SQL Server 2017  |
 |:------------------|:-----------------|:-----------------|:-----------------|
+| **ScalarDB 3.11** | ✅               | ✅               | ✅               |
 | **ScalarDB 3.10** | ✅               | ✅               | ✅               |
 | **ScalarDB 3.9**  | ✅               | ✅               | ✅               |
 | **ScalarDB 3.8**  | ✅               | ✅               | ✅               |
@@ -108,6 +115,7 @@ For recommendations when using JDBC databases, see [JDBC database recommendation
 
 | Version           | MySQL 8.1  | MySQL 8.0  | MySQL 5.7  |
 |:------------------|:-----------|:-----------|:-----------|
+| **ScalarDB 3.11** | ✅         | ✅         | ✅         |
 | **ScalarDB 3.10** | ✅         | ✅         | ✅         |
 | **ScalarDB 3.9**  | ✅         | ✅         | ✅         |
 | **ScalarDB 3.8**  | ✅         | ✅         | ✅         |
@@ -120,6 +128,7 @@ For recommendations when using JDBC databases, see [JDBC database recommendation
 
 | Version           | Oracle 23.2.0-free  | Oracle 21.3.0-xe  | Oracle 18.4.0-xe  |
 |:------------------|:--------------------|:------------------|:------------------|
+| **ScalarDB 3.11** | ✅                  | ✅                | ✅                |
 | **ScalarDB 3.10** | ✅                  | ✅                | ✅                |
 | **ScalarDB 3.9**  | ✅                  | ✅                | ✅                |
 | **ScalarDB 3.8**  | ✅                  | ✅                | ✅                |
@@ -132,6 +141,7 @@ For recommendations when using JDBC databases, see [JDBC database recommendation
 
 | Version           | PostgreSQL 15  | PostgreSQL 14  | PostgreSQL 13  | PostgreSQL 12  |
 |:------------------|:---------------|:---------------|:---------------|:---------------|
+| **ScalarDB 3.11** | ✅             | ✅             | ✅             | ✅             |
 | **ScalarDB 3.10** | ✅             | ✅             | ✅             | ✅             |
 | **ScalarDB 3.9**  | ✅             | ✅             | ✅             | ✅             |
 | **ScalarDB 3.8**  | ✅             | ✅             | ✅             | ✅             |
@@ -144,6 +154,7 @@ For recommendations when using JDBC databases, see [JDBC database recommendation
 
 | Version           | SQLite 3  |
 |:------------------|:----------|
+| **ScalarDB 3.11** | ✅        |
 | **ScalarDB 3.10** | ✅        |
 | **ScalarDB 3.9**  | ✅        |
 | **ScalarDB 3.8**  | ❌        |


### PR DESCRIPTION
## Description

This PR adds an updated version of the supported database docs to ScalarDB 3.7 docs, which should have been included in https://github.com/scalar-labs/docs-scalardb-community/pull/79.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/1419
- PR containing updates to this doc for other versions: https://github.com/scalar-labs/docs-scalardb-community/pull/79

## Changes made

See https://github.com/scalar-labs/scalardb/pull/1419 for details.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
