### PR TITLE
Add out-of-support banner to ScalarDB 3.5 docs

### DIFF
--- a/docs/3.5/add-scalardb-to-your-build.md
+++ b/docs/3.5/add-scalardb-to-your-build.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Add ScalarDB to Your Build
 
 The ScalarDB library is available on the [Maven Central Repository](https://mvnrepository.com/artifact/com.scalar-labs/scalardb). You can add the library as a build dependency to your application by using Gradle or Maven.

--- a/docs/3.5/backup-restore.md
+++ b/docs/3.5/backup-restore.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # How to Back Up and Restore Databases Used Through ScalarDB
 
 Since ScalarDB provides transaction capabilities on top of non-transactional or transactional databases non-invasively, you need to take special care to back up and restore the databases in a transactionally consistent way.

--- a/docs/3.5/configurations.md
+++ b/docs/3.5/configurations.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # ScalarDB Configurations
 
 This page describes the available configurations for ScalarDB.

--- a/docs/3.5/design.md
+++ b/docs/3.5/design.md
@@ -1,4 +1,6 @@
-## Scalar DB design document
+{% include scalardb/end-of-support.html %}
+
+# Scalar DB design document
 
 ## Introduction
 

--- a/docs/3.5/development-configurations.md
+++ b/docs/3.5/development-configurations.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Configuration Guides for ScalarDB
 
 The following is a list of configuration guides for ScalarDB:

--- a/docs/3.5/getting-started-with-scalardb-by-using-kotlin.md
+++ b/docs/3.5/getting-started-with-scalardb-by-using-kotlin.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Getting Started with ScalarDB by Using Kotlin
 
 This getting started tutorial explains how to configure your preferred database in ScalarDB and set up a basic electronic money application by using Kotlin. Since Kotlin has Java interoperability, you can use ScalarDB directly from Kotlin.

--- a/docs/3.5/getting-started-with-scalardb.md
+++ b/docs/3.5/getting-started-with-scalardb.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Getting Started with ScalarDB
 
 This getting started tutorial explains how to configure your preferred database in ScalarDB and set up a basic electronic money application.

--- a/docs/3.5/how-to-handle-exceptions.md
+++ b/docs/3.5/how-to-handle-exceptions.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # A Guide on How to Handle Exceptions
 
 Handling exceptions correctly in Scalar DB is very important.

--- a/docs/3.5/index.md
+++ b/docs/3.5/index.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # ScalarDB
 
 [![CI](https://github.com/scalar-labs/scalardb/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/scalar-labs/scalardb/actions/workflows/ci.yaml)

--- a/docs/3.5/multi-storage-transactions.md
+++ b/docs/3.5/multi-storage-transactions.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Multi-Storage Transactions
 
 ScalarDB transactions can span multiple storages or databases while maintaining ACID compliance by using a feature called *multi-storage transactions*.

--- a/docs/3.5/redirect-getting-started.md
+++ b/docs/3.5/redirect-getting-started.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 ---
 redirect_from: 
   - /docs/3.5/getting-started/

--- a/docs/3.5/requirements.md
+++ b/docs/3.5/requirements.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Requirements and Recommendations for the Underlying Databases of ScalarDB
 
 This document explains the requirements and recommendations in the underlying databases of ScalarDB to make ScalarDB applications work correctly.

--- a/docs/3.5/scalardb-benchmarks/README.md
+++ b/docs/3.5/scalardb-benchmarks/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # ScalarDB Benchmarking Tools
 
 This tutorial describes how to run benchmarking tools for ScalarDB. Database benchmarking is helpful for evaluating how databases perform against a set of standards.

--- a/docs/3.5/scalardb-samples/README.md
+++ b/docs/3.5/scalardb-samples/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # ScalarDB Samples
 
 This repository contains sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):

--- a/docs/3.5/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.5/scalardb-samples/microservice-transaction-sample/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Create a Sample Application That Supports Microservice Transactions
 
 This tutorial describes how to create a sample application that supports microservice transactions in ScalarDB.

--- a/docs/3.5/scalardb-samples/multi-storage-transaction-sample/README.md
+++ b/docs/3.5/scalardb-samples/multi-storage-transaction-sample/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Create a Sample Application That Supports Multi-Storage Transactions
 
 This tutorial describes how to create a sample application that supports the multi-storage transactions feature in ScalarDB.

--- a/docs/3.5/scalardb-samples/scalardb-sample/README.md
+++ b/docs/3.5/scalardb-samples/scalardb-sample/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Create a Sample Application That Uses ScalarDB
 
 This tutorial describes how to create a sample e-commerce application by using ScalarDB.

--- a/docs/3.5/scalardb-samples/scalardb-server-sample/README.md
+++ b/docs/3.5/scalardb-samples/scalardb-server-sample/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
 For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).

--- a/docs/3.5/scalardb-server.md
+++ b/docs/3.5/scalardb-server.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Scalar DB server
 
 Scalar DB server is a gRPC server that implements Scalar DB interface. 

--- a/docs/3.5/scalardb-supported-databases.md
+++ b/docs/3.5/scalardb-supported-databases.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Supported Databases
 
 ScalarDB supports the following databases and their versions.

--- a/docs/3.5/schema-loader.md
+++ b/docs/3.5/schema-loader.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # ScalarDB Schema Loader
 
 ScalarDB has its own data model and schema that maps to the implementation-specific data model and schema. In addition, ScalarDB stores internal metadata, such as transaction IDs, record versions, and transaction statuses, to manage transaction logs and statuses when you use the Consensus Commit transaction manager.

--- a/docs/3.5/schema.md
+++ b/docs/3.5/schema.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Database schema in Scalar DB
 
 Scalar DB has its own data model and schema, that maps to the implementation specific data model and schema.

--- a/docs/3.5/two-phase-commit-transactions.md
+++ b/docs/3.5/two-phase-commit-transactions.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Transactions with a Two-Phase Commit Interface
 
 ScalarDB supports executing transactions with a two-phase commit interface. With the two-phase commit interface, you can execute a transaction that spans multiple processes or applications, like in a microservice architecture.


### PR DESCRIPTION
## Description

This PR adds an out-of-support banner to ScalarDB 3.5 docs to show that version is no longer supported.

## Related issues and/or PRs

N/A

## Changes made

- Added the out-of-support banner to the top of ScalarDB 3.5 docs.
 
## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
