### PR TITLE
Add support for switching the site to dark mode

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@
 remote_theme             : "mmistakes/minimal-mistakes@4.24.0"
 
 minimal_mistakes_skin    : "default" # "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
+minimal_mistakes_skin_dark    : "dark"
 
 # Site Settings
 locale                   : "en-US"

--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ minimal_mistakes_skin_dark    : "dark"
 
 # Site Settings
 locale                   : "en-US"
-title                    : "ScalarDB Community documentation &#124; Scalar, Inc." # To change the "| Docs" site title, see `includes/masthead.html`.
+title                    : "ScalarDB Community Documentation &#124; Scalar, Inc." # To change the "| Docs" site title, see `includes/masthead.html`.
 title_separator          : "-"
 #subtitle                 : ""
 description              : &description "Community version of the cloud-native universal transaction manager in microservice era" # the official description of the parent product

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,7 +14,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" id="theme_source">
 <link rel="preload" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6/css/all.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6/css/all.min.css"></noscript>
 

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -67,7 +67,7 @@
         </ul>
         <!-- Adds support for dark mode (added by josh-wong). -->
         {% if site.minimal_mistakes_skin_dark %}
-        <i class="fas fa-fw fa-sun btn-light-dark-mode" aria-hidden="true" onclick="node1=document.getElementById('theme_source');node2=document.getElementById('theme_source_2');if(node1.getAttribute('rel')=='stylesheet'){node1.setAttribute('rel', 'stylesheet alternate'); node2.setAttribute('rel', 'stylesheet');sessionStorage.setItem('theme', 'dark');}else{node2.setAttribute('rel', 'stylesheet alternate'); node1.setAttribute('rel', 'stylesheet');sessionStorage.setItem('theme', 'light');} return false;"></i>
+        <i class="fas fa-fw fa-lightbulb btn-light-dark-mode" aria-hidden="true" onclick="node1=document.getElementById('theme_source');node2=document.getElementById('theme_source_2');if(node1.getAttribute('rel')=='stylesheet'){node1.setAttribute('rel', 'stylesheet alternate'); node2.setAttribute('rel', 'stylesheet');sessionStorage.setItem('theme', 'dark');}else{node2.setAttribute('rel', 'stylesheet alternate'); node1.setAttribute('rel', 'stylesheet');sessionStorage.setItem('theme', 'light');} return false;"></i>
         {% endif %}
         
         {% if site.search == true %}

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -65,6 +65,11 @@
             {% endif %}
           {% endfor %}
         </ul>
+        <!-- Adds support for dark mode (added by josh-wong). -->
+        {% if site.minimal_mistakes_skin_dark %}
+        <i class="fas fa-fw fa-sun btn-light-dark-mode" aria-hidden="true" onclick="node1=document.getElementById('theme_source');node2=document.getElementById('theme_source_2');if(node1.getAttribute('rel')=='stylesheet'){node1.setAttribute('rel', 'stylesheet alternate'); node2.setAttribute('rel', 'stylesheet');sessionStorage.setItem('theme', 'dark');}else{node2.setAttribute('rel', 'stylesheet alternate'); node1.setAttribute('rel', 'stylesheet');sessionStorage.setItem('theme', 'light');} return false;"></i>
+        {% endif %}
+        
         {% if site.search == true %}
         <button class="search__toggle" type="button">
           <span class="visually-hidden">{{ site.data.ui-text[site.locale].search_label | default: "Toggle search" }}</span>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -51,7 +51,7 @@
                   {% for children in link.children %}
                     <li>
                       <a href="{{ children.url }}"> <!-- links in the header row point to Scalar home page pages, so no need to include the docs site base URL; originally `<a href="{{ site.baseurl }}{{ children.url }}"></a>` (modified by josh-wong) -->
-                        <span>{{ children.title }}</span><br />
+                        <span class="dropdown-content-description-title">{{ children.title }}</span>
                         <span class="dropdown-content-description">{{ children.description }}</span>
                       </a>
                     </li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,6 +12,17 @@
   <head>
     {% include head.html %}
     {% include head/custom.html %}
+    <!-- Added to eliminate flash of unstyled content (FOUC) when going to different pages while using the dark theme (added by josh-wong). -->
+    <style type="text/css">
+      .hidden {display:none;}
+    </style>
+    <script type="text/javascript" src="/assets/js/vendor/jquery/jquery-3.6.0.js"></script>
+    <script type="text/javascript">
+      $('html').addClass('hidden');
+      $(document).ready(function() {
+        $('html').removeClass('hidden');  // Can also use `$('html').removeClass('hidden');` 
+      });
+    </script>
   </head>
 
   <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,26 @@
   </head>
 
   <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}">
+    <!-- Adds a dark theme for visitors to switch to (added by josh-wong). -->
+    {% if site.minimal_mistakes_skin_dark %}
+    <link rel="stylesheet alternate" href="{{ '/assets/css/dark-theme.css' | relative_url }}" id="theme_source_2">
+    <script>
+      let theme = sessionStorage.getItem('theme');
+      if(theme === "dark")
+      {
+        sessionStorage.setItem('theme', 'dark');
+        node1 = document.getElementById('theme_source');
+        node2 = document.getElementById('theme_source_2');
+        node1.setAttribute('rel', 'stylesheet alternate'); 
+        node2.setAttribute('rel', 'stylesheet');
+      }
+      else
+      {
+        sessionStorage.setItem('theme', 'light');
+      }
+    </script>
+    {% endif %}
+    
     {% include_cached skip-links.html %}
     {% include_cached masthead.html %}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,7 +34,10 @@
       }
     </script>
     {% endif %}
-    
+    <!-- Adds support Font Aweosme 5 icons (added by josh-wong). -->
+    <link rel="preload" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css"></noscript>
+
     {% include_cached skip-links.html %}
     {% include_cached masthead.html %}
 

--- a/_sass/minimal-mistakes/_buttons.scss
+++ b/_sass/minimal-mistakes/_buttons.scss
@@ -95,3 +95,61 @@
     font-size: $type-size-7;
   }
 }
+
+/* This button is for switching between light and dark modes (added by josh-wong). */
+.btn-light-dark-mode {
+  /* default */
+  display: inline-block;
+  /* margin-bottom: 0.25em;/* Commented out to remove underline when hovering over buttons (modified by josh-wong). */
+  padding: 0.5em 2em 0.5em 1em; /* Originally `0.5em 1em;` (modified by josh-wong.) */
+  font-family: $sans-serif;
+  font-size: $type-size-4; /* Originally `$type-size-6;` (modified by josh-wong) */
+  font-weight: 500; /* Originally `bold;` (modified by josh-wong). */
+  text-align: center;
+  text-decoration: none;
+  border-width: 0;
+  border-radius: $border-radius;
+  cursor: pointer;
+
+  .icon {
+    margin-right: 0.5em;
+  }
+
+  .icon + .hidden {
+    margin-left: -0.5em; /* override for hidden text*/
+  }
+
+  /* fills width of parent container */
+  &--block {
+    display: block;
+    width: 100%;
+
+    + .btn-light-dark-mode--block {
+      margin-top: 0.25em;
+    }
+  }
+
+  /* disabled */
+  &--disabled {
+    pointer-events: none;
+    cursor: not-allowed;
+    filter: alpha(opacity=65);
+    box-shadow: none;
+    opacity: 0.65;
+  }
+
+  /* extra large button */
+  &--x-large {
+    font-size: $type-size-4;
+  }
+
+  /* large button */
+  &--large {
+    font-size: $type-size-5;
+  }
+
+  /* small button */
+  &--small {
+    font-size: $type-size-7;
+  }
+}

--- a/_sass/minimal-mistakes/_masthead.scss
+++ b/_sass/minimal-mistakes/_masthead.scss
@@ -194,7 +194,7 @@
           line-height: 1em;
         }
         &:hover {
-          background-color: mix(#fff, $scalar-primary-color, 80%);
+          background-color: mix($gray, $background-color, 20%);
         }
       }
     

--- a/_sass/minimal-mistakes/_navigation.scss
+++ b/_sass/minimal-mistakes/_navigation.scss
@@ -304,10 +304,18 @@
         z-index: 1;
         border: 1pt solid $border-color;
       }
+
+      .dropdown-content-description-title {
+        border-bottom: 1pt solid $border-color;
+        display: list-item;
+        padding-bottom: 3px;
+        font-weight: 500;
+      }
   
       .dropdown-content-description {
-        color: $gray;
-        font-weight: 400;
+        color: $text-color;
+        font-weight: normal;
+        padding-top: 6px;
         position: relative;
         box-shadow: none;
       }
@@ -516,6 +524,7 @@
     
     ul {
       padding-left: 0.5em;
+      padding-top: 0.5em; /* Added to add spacing above links to pages in side navigation (added by josh-wong). */
     }
   
     a {
@@ -524,7 +533,7 @@
       /* Added a hover element to make navigation items more prominent when a visitor hovers over a link (added by josh-wong) */
       &:hover {
         color: $scalar-primary-color;
-        background-color: mix(#fff, $scalar-primary-color, 90%);
+        /* background-color: mix(#fff, $scalar-primary-color, 90%); */ /* Commented out since the color does not comply when the dark theme is used (changed by josh-wong). */
       }
     }
   
@@ -534,9 +543,13 @@
       padding-left: 0.5em;
       padding-right: 7px;
       font-weight: 500;
-      color: $scalar-primary-color;
-      background-color: mix(#fff, $scalar-primary-color, 90%); /* Added to make the page that visitors are on more prominent in the side navigation (added by josh-wong) */
+      color: $link-color-visited;
+      background-color: $scalar-light-gray-background-color; /* Added to make the page that visitors are on more prominent in the side navigation (added by josh-wong) */
       display: block; /* Added to make the background color take up 100% of space in the side navigation (added by josh-wong) */
+
+      &:hover {
+        color: $link-color-hover;
+      }
     }
   
     @include breakpoint(max-width $large - 1px) {
@@ -576,14 +589,15 @@
   }
   
   .nav__sub-title {
-    display: block;
-    margin: 0.5rem 0;
-    padding: 0 0 0.25rem 0; /* Reduced spacing above product titles in side navigation; originally `padding: 0.25rem 0;` (modified by josh-wong) */
+    display: inline-block; /* Changed to make the top sub-title not transform/glitch when hovering over links in the side navigation (originally `display: block`). (modified by josh-wong). */
+    margin: 0 0; /* Changed to reduce spacing after the top sub-title in the side navigation (originally `margin: 0.5rem 0`). (modified by josh-wong). */
+    padding: 0 0 0.2rem 0; /* Reduced spacing above product titles in side navigation; originally `padding: 0.25rem 0;` (modified by josh-wong). */
     font-family: $sans-serif-narrow;
     font-size: $type-size-6;
     font-weight: bold;
     text-transform: uppercase;
     border-bottom: 1px solid $border-color;
+    width: 100%; /* Added to extend the line under subtitles across the side navigation while respecting the padding specified` (modified by josh-wong). */
   }
   
   /*
@@ -609,7 +623,7 @@
   
     // Scrollspy marks toc items as .active when they are in focus
     .active a {
-      @include yiq-contrasted(mix(#fff, $scalar-primary-color, 90%));
+      @include yiq-contrasted($scalar-light-gray-background-color); // Changed color to work in both light and dark mode; originally `@include yiq-contrasted(mix(#fff, $scalar-primary-color, 90%));` (added by josh-wong).
     }
   }
   
@@ -632,9 +646,10 @@
       line-height: 1.5;
       border-bottom: 1px solid $border-color;
   
-      &:hover {
-        color: $text-color;
-      }
+      /* Commented out this hover class because it causes the background of TOC items to change the background color when hovered over. Commenting out this class has no ill effects in neither light nor dark themes (modified by josh-wong). */
+      // &:hover {
+      //   color: $text-color;
+      // }
     }
   
     li ul > li a {

--- a/_sass/minimal-mistakes/_page.scss
+++ b/_sass/minimal-mistakes/_page.scss
@@ -77,6 +77,7 @@ body {
       max-height: 400px;
       margin: auto;
       display: block;
+      background-color: #ffffff;
     }
   }
 }

--- a/_sass/minimal-mistakes/_page.scss
+++ b/_sass/minimal-mistakes/_page.scss
@@ -226,12 +226,12 @@ body {
     .page__title,
     .page__meta,
     .btn {
-      color: $dark-gray;
+      color: $text-color;
     }
 
     .page__lead {
       max-width: $medium;
-      color: $gray;
+      color: $text-color;
     }
 
     .page__title {

--- a/_sass/minimal-mistakes/_search.scss
+++ b/_sass/minimal-mistakes/_search.scss
@@ -14,7 +14,7 @@
   height: $nav-toggle-height;
   border: 0;
   outline: none;
-  color: $primary-color;
+  color: $text-color;
   background-color: transparent;
   cursor: pointer;
   -webkit-transition: 0.2s;

--- a/_sass/minimal-mistakes/_sidebar.scss
+++ b/_sass/minimal-mistakes/_sidebar.scss
@@ -67,10 +67,10 @@
       /* Added to give hover effect to items in navigation (added by josh-wong) */
       li {
         &:hover {
-          background-color: mix(#fff, $scalar-primary-color, 90%);
-          margin-left: -10px;
-          padding-left: 10px;
-          padding-right: 7px;
+          background-color: $scalar-light-gray-background-color;
+          display: block;
+          margin-left: -0.5em; /* Added this property to add spacing at the beginning of the link when hovered over. (added by josh-wong) */
+          padding-left: 0.5em; /* Added this property to add spacing at the beginning of the link when hovered over. (added by josh-wong) */
         }
       }
     }
@@ -101,14 +101,14 @@
     a {
       display: block;
       padding: 0.5em 1em 0.3em 1em;
-      color: $background-color;
+      color: $text-color;
       text-decoration: none;
       -webkit-transition: none;
       transition: none;
       font-size: $type-size-5-5;
   
       &:hover {
-        color: $background-color;
+        color: $lighter-gray;
       }
     }
   }
@@ -139,6 +139,7 @@
       color: $background-color;
       cursor: pointer;
       opacity: unset;
+      color: $lighter-gray;
   
       &:before {
         content: "";
@@ -185,6 +186,7 @@
       vertical-align: middle;
       padding-top: 2px;
       float: right;
+      color: $lighter-gray;
     }
   
     .version-dropdown-content {
@@ -209,7 +211,7 @@
     .version-dropdown-content a {
       padding: 0 15px 0 15px;
       margin: 1px;
-      color: $dark-gray;
+      color: $text-color;
       line-height: 1.6em;
       margin-bottom: 0;
     }

--- a/_sass/minimal-mistakes/_tabbed-content.scss
+++ b/_sass/minimal-mistakes/_tabbed-content.scss
@@ -24,8 +24,8 @@
 
 /* Change background color of buttons on hover */
 .tab button:hover {
-  color: $scalar-primary-color;
-  background-color: mix(#fff, $scalar-primary-color, 90%);
+  color: mix(#fff, $scalar-primary-color, 10%);
+  /* background-color: mix(#fff, $scalar-primary-color, 90%); */ /* Commented out because the background becomes too bright in dark mode (modified by josh-wong). */
   border-bottom: 4px solid $scalar-primary-color;
 }
 

--- a/_sass/minimal-mistakes/_utilities.scss
+++ b/_sass/minimal-mistakes/_utilities.scss
@@ -218,7 +218,7 @@ body:hover .visually-hidden button {
 
     /* Makes social icons lighter when hovered over (added by josh-wong) */
     &:hover {
-      color: $scalar-light-gray-background-color;
+      color: $lighter-gray;
     }
   }
 
@@ -227,7 +227,7 @@ body:hover .visually-hidden button {
 
     /* Makes social icons lighter when hovered over (added by josh-wong) */
     &:hover {
-      color: $scalar-light-gray-background-color;
+      color: $lighter-gray;
     }
   }
 
@@ -237,7 +237,7 @@ body:hover .visually-hidden button {
 
     /* Makes social icons lighter when hovered over (added by josh-wong) */
     &:hover {
-      color: $scalar-light-gray-background-color;
+      color: $lighter-gray;
     }
   }
 
@@ -248,7 +248,7 @@ body:hover .visually-hidden button {
 
     /* Makes social icons lighter when hovered over (added by josh-wong) */
     &:hover {
-      color: $scalar-light-gray-background-color;
+      color: $lighter-gray;
     }
   }
 
@@ -257,7 +257,7 @@ body:hover .visually-hidden button {
 
     /* Makes social icons lighter when hovered over (added by josh-wong) */
     &:hover {
-      color: $scalar-light-gray-background-color;
+      color: $lighter-gray;
     }
   }
 
@@ -266,7 +266,7 @@ body:hover .visually-hidden button {
 
     /* Makes social icons lighter when hovered over (added by josh-wong) */
     &:hover {
-      color: $scalar-light-gray-background-color;
+      color: $lighter-gray;
     }
   }
 
@@ -277,7 +277,7 @@ body:hover .visually-hidden button {
 
     /* Makes social icons lighter when hovered over (added by josh-wong) */
     &:hover {
-      color: $scalar-light-gray-background-color;
+      color: $lighter-gray;
     }
   }
 
@@ -286,7 +286,7 @@ body:hover .visually-hidden button {
 
     /* Makes social icons lighter when hovered over (added by josh-wong) */
     &:hover {
-      color: $scalar-light-gray-background-color;
+      color: $lighter-gray;
     }
   }
 
@@ -295,7 +295,7 @@ body:hover .visually-hidden button {
 
     /* Makes social icons lighter when hovered over (added by josh-wong) */
     &:hover {
-      color: $scalar-light-gray-background-color;
+      color: $lighter-gray;
     }
   }
 
@@ -304,7 +304,7 @@ body:hover .visually-hidden button {
 
     /* Makes social icons lighter when hovered over (added by josh-wong) */
     &:hover {
-      color: $scalar-light-gray-background-color;
+      color: $lighter-gray;
     }
   }
 
@@ -314,7 +314,7 @@ body:hover .visually-hidden button {
         
     /* Makes social icons lighter when hovered over (added by josh-wong) */
     &:hover {
-      color: $scalar-light-gray-background-color;
+      color: $lighter-gray;
     }
   }
 
@@ -324,7 +324,7 @@ body:hover .visually-hidden button {
     
     /* Makes social icons lighter when hovered over (added by josh-wong) */
     &:hover {
-      color: $scalar-light-gray-background-color;
+      color: $lighter-gray;
     }
   }
 

--- a/_sass/minimal-mistakes/skins/_dark.scss
+++ b/_sass/minimal-mistakes/skins/_dark.scss
@@ -1,28 +1,51 @@
 /* ==========================================================================
-   Dark skin
+   Dark theme
    ========================================================================== */
 
 /* Colors */
-$background-color: #252a34 !default;
+$background-color: #121212 !default;
 $text-color: #eaeaea !default;
-$primary-color: #00adb5 !default;
+$primary-color: #2673BB !default;
 $border-color: mix(#fff, $background-color, 20%) !default;
 $code-background-color: mix(#000, $background-color, 15%) !default;
 $code-background-color-dark: mix(#000, $background-color, 20%) !default;
+$gray: #7a8288 !default;
+$dark-gray: #eaeaea !default; /* This color isn't really gray and should be refactored. However, doing so would take considerable time, so I'm leaving it as is for now (modified by josh-wong). */
 $form-background-color: mix(#000, $background-color, 15%) !default;
 $footer-background-color: mix(#000, $background-color, 30%) !default;
-$link-color: mix($primary-color, $text-color, 40%) !default;
-$link-color-hover: mix(#fff, $link-color, 25%) !default;
-$link-color-visited: mix(#000, $link-color, 25%) !default;
+$lighter-gray: mix(#fff, $gray, 90%) !default;
+$link-color: mix(#fff, #2673BB, 20%) !default;
+$link-color-hover: mix(#fff, $link-color, 50%) !default;
+$link-color-visited: mix(#fff, $link-color, 15%) !default;
+$link-color-visited: mix(#fff, #2673BB, 20%) !default;
 $masthead-link-color: $text-color !default;
 $masthead-link-color-hover: mix(#000, $text-color, 20%) !default;
 $navicon-link-color-hover: mix(#000, $background-color, 30%) !default;
+$scalar-primary-color: #2673BB !default;
+$scalar-light-gray-background-color: #1c1c1c !default; /* This color isn't really light gray and should be refactored. However, doing so would take considerable time, so I'm leaving it as is for now (modified by josh-wong). */
+
+/* syntax highlighting (base16) */
+$base00: #1C1C1C !default;
+
+/*
+  Other
+  ========================================================================== */
+
+  $border-radius: 0 !default;
+  $box-shadow: 0 5px 5px rgba(0, 0, 0, 0.125) !default;
+  $nav-height: 2em !default;
+  $nav-toggle-height: 2rem !default;
+  $navicon-width: 1.5rem !default;
+  $navicon-height: 0.25rem !default;
+  $global-transition: all 0.2s ease-in-out !default;
+  $intro-transition: intro 0.3s both !default;
+   
 
 .author__urls.social-icons i,
 .author__urls.social-icons .svg-inline--fa,
 .page__footer-follow .social-icons i,
 .page__footer-follow .social-icons .svg-inline--fa  {
-  color: inherit;
+  color: $lighter-gray;
 }
 
 .ais-search-box .ais-search-box--input {

--- a/assets/css/dark-theme.scss
+++ b/assets/css/dark-theme.scss
@@ -1,0 +1,8 @@
+---
+# Only the main Sass file needs front matter (the dashes are enough)
+---
+
+@charset "utf-8";
+
+@import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin_dark | default: 'default' }}"; // skin
+@import "minimal-mistakes"; // main partials


### PR DESCRIPTION
## Description

This PR adds support for switching the site to dark mode. 

Some visitors prefer using dark themes to minimize brightness on their screens. By providing an option to switch to dark mode, we can make this docs site easier on the eyes when in low-light situations or when visitors prefer darker environments. 

## Related issues and/or PRs

N/A

## Changes made

- Created dark mode styles.
- Added and modify styles in other files to support dark mode.
- Added support for Font Awesome 5 icons so that we can use more icons, specifically for the light-dark toggle.
- Added JavaScript to eliminate flash of unstyled content (FOUC) when switching to or from dark mode and when navigating between pages when in dark mode.
- Added white background to .png images in light and dark mode since some images have transparent backgrounds that make the text hard to read when in dark mode.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A