### PR TITLE
Change light and dark theme toggle icon and method for saving theme to storage

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,6 +15,15 @@
 
 <!-- For all browsers -->
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" id="theme_source">
+
+<!-- Dark mode - Uncomment the following to allow for automatic light mode or dark mode based on whether the OS is in dark mode (added by josh-wong). -->
+<!-- {% if site.minimal_mistakes_skin_dark %}
+  <meta name="color-scheme" content="light dark">
+  <style>
+    @import url("{{ '/assets/css/dark-theme.css' | relative_url }}") (prefers-color-scheme: dark);
+  </style>
+{% endif %} -->
+
 <link rel="preload" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6/css/all.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6/css/all.min.css"></noscript>
 

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -67,9 +67,8 @@
         </ul>
         <!-- Adds support for dark mode (added by josh-wong). -->
         {% if site.minimal_mistakes_skin_dark %}
-        <i class="fas fa-fw fa-lightbulb btn-light-dark-mode" aria-hidden="true" onclick="node1=document.getElementById('theme_source');node2=document.getElementById('theme_source_2');if(node1.getAttribute('rel')=='stylesheet'){node1.setAttribute('rel', 'stylesheet alternate'); node2.setAttribute('rel', 'stylesheet');localStorage.setItem('theme', 'dark');}else{node2.setAttribute('rel', 'stylesheet alternate'); node1.setAttribute('rel', 'stylesheet');localStorage.setItem('theme', 'light');} return false;"></i>
+        <i class="fas fa-lightbulb btn-light-dark-mode" id="toggle" aria-hidden="true" onclick="dark_mode_btn_click()"></i>
         {% endif %}
-        
         {% if site.search == true %}
         <button class="search__toggle" type="button">
           <span class="visually-hidden">{{ site.data.ui-text[site.locale].search_label | default: "Toggle search" }}</span>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -65,9 +65,9 @@
             {% endif %}
           {% endfor %}
         </ul>
-        <!-- Adds support for dark mode (added by josh-wong). -->
+        <!-- Adds toggle for light and dark modes for dark mode (added by josh-wong). -->
         {% if site.minimal_mistakes_skin_dark %}
-        <i class="fas fa-lightbulb btn-light-dark-mode" id="toggle" aria-hidden="true" onclick="dark_mode_btn_click()"></i>
+        <i class="fas fa-adjust btn-light-dark-mode" id="toggle" aria-hidden="true" onclick="dark_mode_btn_click()"></i>
         {% endif %}
         {% if site.search == true %}
         <button class="search__toggle" type="button">

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -67,7 +67,7 @@
         </ul>
         <!-- Adds support for dark mode (added by josh-wong). -->
         {% if site.minimal_mistakes_skin_dark %}
-        <i class="fas fa-fw fa-lightbulb btn-light-dark-mode" aria-hidden="true" onclick="node1=document.getElementById('theme_source');node2=document.getElementById('theme_source_2');if(node1.getAttribute('rel')=='stylesheet'){node1.setAttribute('rel', 'stylesheet alternate'); node2.setAttribute('rel', 'stylesheet');sessionStorage.setItem('theme', 'dark');}else{node2.setAttribute('rel', 'stylesheet alternate'); node1.setAttribute('rel', 'stylesheet');sessionStorage.setItem('theme', 'light');} return false;"></i>
+        <i class="fas fa-fw fa-lightbulb btn-light-dark-mode" aria-hidden="true" onclick="node1=document.getElementById('theme_source');node2=document.getElementById('theme_source_2');if(node1.getAttribute('rel')=='stylesheet'){node1.setAttribute('rel', 'stylesheet alternate'); node2.setAttribute('rel', 'stylesheet');localStorage.setItem('theme', 'dark');}else{node2.setAttribute('rel', 'stylesheet alternate'); node1.setAttribute('rel', 'stylesheet');localStorage.setItem('theme', 'light');} return false;"></i>
         {% endif %}
         
         {% if site.search == true %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -48,3 +48,25 @@
 
 <!-- The following script allows users to press a button to copy content in a code block to a clipboard. (added by josh-wong) -->
 <script src="/assets/js/copy-code-to-clipboard.js"></script>
+
+<!-- Adds support for dark mode. Would be nice if we could have the button change from a moon to a sun when switching to dark mode (and from a sun to a moon when switching to light mode) (added by josh-wong).-->
+<script>
+  function dark_mode_btn_click() {
+    var node1 = document.getElementById('theme_source');
+    var node2 = document.getElementById('theme_source_2');
+    if(node1.getAttribute('rel')=='stylesheet'){
+      node2.setAttribute('rel', 'stylesheet');
+      setTimeout(function(){
+        node1.setAttribute('rel', 'stylesheet alternate');
+      }, 10);
+      localStorage.setItem('theme', 'dark');
+    }else{
+      node1.setAttribute('rel', 'stylesheet');
+      setTimeout(function(){
+        node2.setAttribute('rel', 'stylesheet alternate');
+      }, 10);
+      localStorage.setItem('theme', 'light');
+    }
+    return false;
+  }
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,10 +30,10 @@
     {% if site.minimal_mistakes_skin_dark %}
     <link rel="stylesheet alternate" href="{{ '/assets/css/dark-theme.css' | relative_url }}" id="theme_source_2">
     <script>
-      let theme = sessionStorage.getItem('theme');
+      let theme = localStorage.getItem('theme');
       if(theme === "dark")
       {
-        sessionStorage.setItem('theme', 'dark');
+        localStorage.setItem('theme', 'dark');
         node1 = document.getElementById('theme_source');
         node2 = document.getElementById('theme_source_2');
         node1.setAttribute('rel', 'stylesheet alternate'); 
@@ -41,7 +41,7 @@
       }
       else
       {
-        sessionStorage.setItem('theme', 'light');
+        localStorage.setItem('theme', 'light');
       }
     </script>
     {% endif %}

--- a/assets/css/dark-theme.scss
+++ b/assets/css/dark-theme.scss
@@ -4,5 +4,5 @@
 
 @charset "utf-8";
 
-@import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin_dark | default: 'default' }}"; // skin
+@import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin_dark | default: 'dark' }}"; // skin
 @import "minimal-mistakes"; // main partials


### PR DESCRIPTION
## Description

This PR changes the following:

- **Light and dark theme toggle icon:** For some visitors, a lightbulb may not be a familiar icon to toggle themes.
- **Method for saving light or dark mode to storage in the browser:** Visitors who toggle the site to dark mode are more likely to see the site in dark mode automatically when they re-visit the site in the future.

## Related issues and/or PRs

- https://github.com/scalar-labs/docs-scalardb-community/pull/92

## Changes made

- Changed the dark-mode toggle from `lightbulb` to `adjust`.
- Changed the method for saving the dark or light mode from `sessionStorage` to `localStorage`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A