### PR TITLE
Add workflow to update the "docs/latest" folder

### DIFF
--- a/.github/workflows/update-latest-docs.yml
+++ b/.github/workflows/update-latest-docs.yml
@@ -1,0 +1,33 @@
+# Workflow for updating the `latest` folder to include the same content as the latest version of docs
+name: 🔄 Update latest version of docs
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "3.12" # This path *must* match the folder name of the latest product release version.
+  # The following `workflow_dispatch` lines are for scheduling this workflow to reduce GitHub actions. We might want to consider scheduling docs to sync to the docs site repos in the future if we use too many action minutes in our monthly GitHub quota.
+  # workflow_dispatch:
+  # schedule:
+  #   - cron: '0 1 * * 1,4' # Run at 1:00 AM Universal Time Coordinated (UTC) / 10:00 AM Japan Standard Time (JST) on Mondays and Thursdays.
+
+jobs:
+  update-latest-version-of-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Update the `latest` folder to include the same content as the latest version of docs
+        uses: dmnemec/copy_file_to_another_repo_action@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.SYNC_DOCS_PAT }}
+        with:
+          source_file: "docs/3.12/" # This path *must* match the folder name of the latest version.
+          destination_repo: "scalar-labs/docs-scalardb" # Target repo
+          destination_folder: "docs/latest/" # Folder to sync to
+          destination_branch_create: "scalardb/update-docs-latest"
+          user_name: "josh-wong"
+          user_email: "joshua.wong@scalar-labs.com"
+          commit_message: "AUTO: Update the latest version of docs"
+          use_rsync: rsync -avh


### PR DESCRIPTION
## Description

This PR adds a workflow to update the `docs/latest` folder with the latest version of docs. Automating this step will eliminate a manual step (copying contents to both the version number folder and the `latest` folder) and potential mistakes related to that process.

## Related issues and/or PRs

N/A

## Changes made

- Added a workflow to sync the latest version number folder that contains docs to the `docs/latest` folder.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The file `.github/workflows/update-latest-docs.yml` is used to update the `docs/latest` folder with the latest version of docs. Because of how that workflow is currently configured, we need to update the version in the workflow when a new version is released.

In the future, detecting which version number is the latest (rather than manually updating the version number in the workflow) so that the `docs/latest` folder can be automatically updated would be nice.