### PR TITLE
Re-add workflow to update the "docs/latest" folder

### DIFF
--- a/.github/workflows/update-latest-docs.yml
+++ b/.github/workflows/update-latest-docs.yml
@@ -1,0 +1,33 @@
+# Workflow for updating the `latest` folder to include the same content as the latest version of docs
+name: 🔄 Update latest version of docs
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "docs/3.12" # This path *must* match the folder name of the latest product release version.
+  # The following `workflow_dispatch` lines are for scheduling this workflow to reduce GitHub actions. We might want to consider scheduling docs to sync to the docs site repos in the future if we use too many action minutes in our monthly GitHub quota.
+  # workflow_dispatch:
+  # schedule:
+  #   - cron: '0 1 * * 1,4' # Run at 1:00 AM Universal Time Coordinated (UTC) / 10:00 AM Japan Standard Time (JST) on Mondays and Thursdays.
+
+jobs:
+  update-latest-version-of-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Update the `latest` folder to include the same content as the latest version of docs
+        uses: dmnemec/copy_file_to_another_repo_action@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.SYNC_DOCS_PAT }}
+        with:
+          source_file: "docs/3.12/" # This path *must* match the folder name of the latest version.
+          destination_repo: "scalar-labs/docs-scalardb-community" # Target repo
+          destination_folder: "docs/latest/" # Folder to sync to
+          destination_branch_create: "scalardb/update-docs-latest"
+          user_name: "josh-wong"
+          user_email: "joshua.wong@scalar-labs.com"
+          commit_message: "AUTO: Update the latest version of docs"
+          use_rsync: rsync -avh


### PR DESCRIPTION
> [!CAUTION]
>
> This PR should not be merged until we update the workflow that builds Jekyll; otherwise, the workflow for Jekyll will be built twice. Instead, the workflow for building Jekyll should run after this workflow is completed or if this workflow doesn't need to run.

## Description

This PR re-adds a workflow to update the `docs/latest` folder.

## Related issues and/or PRs

- https://github.com/scalar-labs/docs-scalardb-community/pull/103

## Changes made

- Re-added a workflow to update the `docs/latest` folder with the latest version of docs.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A