### PR TITLE
Remove irrelevant pages from search results

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -79,7 +79,6 @@ footer:
 include:
   - .htaccess
   - docs
-  - _home
 # exclude:
 #   - '*.sublime-project'
 #   - '*.sublime-workspace'
@@ -347,6 +346,13 @@ defaults:
       search: false
 
   # Remove irrelevant search results
+  - scope:
+      path: "redirects.json"
+    values:
+      layout: none
+      hidden: true
+      search: false
+      sitemap: false
   - scope:
       path: "assets"
     values:


### PR DESCRIPTION
## Description

This PR removes irrelevant, non-documentation-related pages from search results.

## Related issues and/or PRs

N/A

## Changes made

- Remove the `_home` directory from the included output.
  - Pages in this directory are still published.
- Hide an auto-generated page from search results.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A