### PR TITLE
Fix broken links

### DIFF
--- a/docs/3.10/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.10/scalardb-samples/microservice-transaction-sample/README.md
@@ -108,7 +108,7 @@ $ cd scalardb-samples/microservice-transaction-sample
 
 ### Start Cassandra and MySQL
 
-Cassandra and MySQL are already configured for the sample application, as shown in [`database.properties`](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
+Cassandra and MySQL are already configured for the sample application, as shown in [`database-cassandra.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-cassandra.properties) and [`database-mysql.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-mysql.properties), respectively. For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
 
 To start Cassandra and MySQL, which are included in the Docker container for the sample application, run the following command:
 

--- a/docs/3.11/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.11/scalardb-samples/microservice-transaction-sample/README.md
@@ -108,7 +108,7 @@ $ cd scalardb-samples/microservice-transaction-sample
 
 ### Start Cassandra and MySQL
 
-Cassandra and MySQL are already configured for the sample application, as shown in [`database.properties`](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
+Cassandra and MySQL are already configured for the sample application, as shown in [`database-cassandra.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-cassandra.properties) and [`database-mysql.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-mysql.properties), respectively. For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
 
 To start Cassandra and MySQL, which are included in the Docker container for the sample application, run the following command:
 

--- a/docs/3.12/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.12/scalardb-samples/microservice-transaction-sample/README.md
@@ -108,7 +108,7 @@ $ cd scalardb-samples/microservice-transaction-sample
 
 ### Start Cassandra and MySQL
 
-Cassandra and MySQL are already configured for the sample application, as shown in [`database.properties`](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
+Cassandra and MySQL are already configured for the sample application, as shown in [`database-cassandra.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-cassandra.properties) and [`database-mysql.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-mysql.properties), respectively. For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
 
 To start Cassandra and MySQL, which are included in the Docker container for the sample application, run the following command:
 

--- a/docs/3.4/getting-started-with-scalardb.md
+++ b/docs/3.4/getting-started-with-scalardb.md
@@ -268,7 +268,7 @@ These are just simple examples of how Scalar DB is used. For more information, p
     * [scalardb-server](https://javadoc.io/doc/com.scalar-labs/scalardb-server/latest/index.html) - Scalar DB Server that is the gRPC interfarce of Scalar DB
 * [Requirements in the underlining databases](requirements.md)
 * [Database schema in Scalar DB](schema.md)
-* [Schema Loader](https://github.com/scalar-labs/scalardb/tree/master/schema-loader/README.md)
+* [Schema Loader](schema-loader.md)
 * [How to Back up and Restore](backup-restore.md)
 * [Multi-storage Transactions](multi-storage-transactions.md)
 * [Two-phase Commit Transactions](two-phase-commit-transactions.md)

--- a/docs/3.4/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.4/scalardb-samples/microservice-transaction-sample/README.md
@@ -99,7 +99,7 @@ $ cd scalardb-samples/microservice-transaction-sample
 
 ### Start Cassandra and MySQL
 
-Cassandra and MySQL are already configured for the sample application, as shown in [`database.properties`](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
+Cassandra and MySQL are already configured for the sample application, as shown in [`database-cassandra.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-cassandra.properties) and [`database-mysql.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-mysql.properties), respectively. For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
 
 To start Cassandra and MySQL, which are included in the Docker container for the sample application, run the following command:
 

--- a/docs/3.4/scalardb-samples/scalardb-server-sample/README.md
+++ b/docs/3.4/scalardb-samples/scalardb-server-sample/README.md
@@ -2,7 +2,7 @@
 
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
-For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md).
+For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
 More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.md).
 
 ## Sample application
@@ -56,7 +56,7 @@ Please note that we should wait around a bit more than one minute because Scalar
 ```shell
 $ docker-compose -f docker-compose-cassandra.yml up -d
 ```
-*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
+*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
 
 ### ScalarDB client
 The sample application uses a client that implements ScalarDB interface.

--- a/docs/3.4/schema-loader.md
+++ b/docs/3.4/schema-loader.md
@@ -1,0 +1,393 @@
+# Scalar DB Schema Loader
+
+Scalar DB Schema Loader creates and deletes Scalar DB schemas (namespaces and tables) on the basis of a provided schema file.
+Also, it automatically adds the Scalar DB transaction metadata (used in the Consensus Commit protocol) to the tables when you set the `transaction` parameter to `true` in the schema file.
+
+There are two ways to specify general CLI options in Schema Loader:
+  - Pass a Scalar DB configuration file and database/storage-specific options additionally.
+  - Pass the options without a Scalar DB configuration (Deprecated).
+
+Note that this tool supports only basic options to create/delete a table.
+If you want to use advanced features of the database, please alter your tables after creating them with this tool.
+
+# Usage
+
+## Install
+
+The release versions of `schema-loader` can be downloaded from [releases](https://github.com/scalar-labs/scalardb/releases) page of Scalar DB.
+
+## Build
+
+In case you want to build `schema-loader` from the source:
+```console
+$ ./gradlew schema-loader:shadowJar
+```
+- The built fat jar file is `schema-loader/build/libs/scalardb-schema-loader-<version>.jar`
+
+## Docker
+
+You can pull the docker image from [Scalar's container registry](https://github.com/orgs/scalar-labs/packages/container/package/scalardb-schema-loader).
+```console
+docker run --rm -v <your_local_schema_file_path>:<schema_file_path_in_docker> [-v <your_local_config_file_path>:<config_file_path_in_docker>] ghcr.io/scalar-labs/scalardb-schema-loader:<version> <command_arguments>
+```
+- Note that you can specify the same command arguments even if you use the fat jar or the container. The example commands in the next section are shown with a jar, but you can run the commands with the container in the same way by replacing `java -jar scalardb-schema-loader-<version>.jar` with `docker run --rm -v <your_local_schema_file_path>:<schema_file_path_in_docker> [-v <your_local_config_file_path>:<config_file_path_in_docker>] ghcr.io/scalar-labs/scalardb-schema-loader:<version>`.
+
+You can also build the docker image as follows.
+```console
+$ ./gradlew schema-loader:docker
+```
+
+## Run
+
+### Available commands
+
+For using a config file:
+```console
+Usage: java -jar scalardb-schema-loader-<version>.jar [-D] [--coordinator]
+       [--no-backup] [--no-scaling] -c=<configPath>
+       [--compaction-strategy=<compactionStrategy>] [-f=<schemaFile>]
+       [--replication-factor=<replicaFactor>]
+       [--replication-strategy=<replicationStrategy>] [--ru=<ru>]
+Create/Delete schemas in the storage defined in the config file
+  -c, --config=<configPath>
+                      Path to the config file of Scalar DB
+      --compaction-strategy=<compactionStrategy>
+                      The compaction strategy, must be LCS, STCS or TWCS
+                        (supported in Cassandra)
+      --coordinator   Create/delete coordinator table
+  -D, --delete-all    Delete tables
+  -f, --schema-file=<schemaFile>
+                      Path to the schema json file
+      --no-backup     Disable continuous backup (supported in DynamoDB)
+      --no-scaling    Disable auto-scaling (supported in DynamoDB, Cosmos DB)
+      --replication-factor=<replicaFactor>
+                      The replication factor (supported in Cassandra)
+      --replication-strategy=<replicationStrategy>
+                      The replication strategy, must be SimpleStrategy or
+                        NetworkTopologyStrategy (supported in Cassandra)
+      --ru=<ru>       Base resource unit (supported in DynamoDB, Cosmos DB)
+```
+
+For Cosmos DB (Deprecated. Please use the command using a config file instead):
+```console
+Usage: java -jar scalardb-schema-loader-<version>.jar --cosmos [-D]
+       [--no-scaling] -f=<schemaFile> -h=<uri> -p=<key> [-r=<ru>]
+Create/Delete Cosmos DB schemas
+  -D, --delete-all       Delete tables
+  -f, --schema-file=<schemaFile>
+                         Path to the schema json file
+  -h, --host=<uri>       Cosmos DB account URI
+      --no-scaling       Disable auto-scaling for Cosmos DB
+  -p, --password=<key>   Cosmos DB key
+  -r, --ru=<ru>          Base resource unit
+```
+
+For DynamoDB (Deprecated. Please use the command using a config file instead):
+```console
+Usage: java -jar scalardb-schema-loader-<version>.jar --dynamo [-D]
+       [--no-backup] [--no-scaling] [--endpoint-override=<endpointOverride>]
+       -f=<schemaFile> -p=<awsSecKey> [-r=<ru>] --region=<awsRegion>
+       -u=<awsKeyId>
+Create/Delete DynamoDB schemas
+  -D, --delete-all           Delete tables
+      --endpoint-override=<endpointOverride>
+                             Endpoint with which the DynamoDB SDK should
+                               communicate
+  -f, --schema-file=<schemaFile>
+                             Path to the schema json file
+      --no-backup            Disable continuous backup for DynamoDB
+      --no-scaling           Disable auto-scaling for DynamoDB
+  -p, --password=<awsSecKey> AWS access secret key
+  -r, --ru=<ru>              Base resource unit
+      --region=<awsRegion>   AWS region
+  -u, --user=<awsKeyId>      AWS access key ID
+```
+
+For Cassandra (Deprecated. Please use the command using a config file instead):
+```console
+Usage: java -jar scalardb-schema-loader-<version>.jar --cassandra [-D]
+       [-c=<compactionStrategy>] -f=<schemaFile> -h=<hostIp>
+       [-n=<replicationStrategy>] [-p=<password>] [-P=<port>]
+       [-R=<replicationFactor>] [-u=<user>]
+Create/Delete Cassandra schemas
+  -c, --compaction-strategy=<compactionStrategy>
+                        Cassandra compaction strategy, must be LCS, STCS or TWCS
+  -D, --delete-all      Delete tables
+  -f, --schema-file=<schemaFile>
+                        Path to the schema json file
+  -h, --host=<hostIp>   Cassandra host IP
+  -n, --network-strategy=<replicationStrategy>
+                        Cassandra network strategy, must be SimpleStrategy or
+                          NetworkTopologyStrategy
+  -p, --password=<password>
+                        Cassandra password
+  -P, --port=<port>     Cassandra Port
+  -R, --replication-factor=<replicationFactor>
+                        Cassandra replication factor
+  -u, --user=<user>     Cassandra user
+```
+
+For a JDBC database (Deprecated. Please use the command using a config file instead):
+```console
+Usage: java -jar scalardb-schema-loader-<version>.jar --jdbc [-D]
+       -f=<schemaFile> -j=<url> -p=<password> -u=<user>
+Create/Delete JDBC schemas
+  -D, --delete-all       Delete tables
+  -f, --schema-file=<schemaFile>
+                         Path to the schema json file
+  -j, --jdbc-url=<url>   JDBC URL
+  -p, --password=<password>
+                         JDBC password
+  -u, --user=<user>      JDBC user
+```
+
+### Create namespaces and tables
+
+For using a config file (Sample config file can be found [here](../conf/database.properties)):
+```console
+$ java -jar scalardb-schema-loader-<version>.jar --config <PATH_TO_CONFIG_FILE> -f schema.json [--coordinator]
+```
+  - if `--coordinator` is specified, the coordinator table will be created.
+
+For using CLI arguments fully for configuration (Deprecated. Please use the command using a config file instead):
+```console
+# For Cosmos DB
+$ java -jar scalardb-schema-loader-<version>.jar --cosmos -h <COSMOS_DB_ACCOUNT_URI> -p <COSMOS_DB_KEY> -f schema.json [-r BASE_RESOURCE_UNIT]
+```
+  - `<COSMOS_DB_KEY>` you can use a primary key or a secondary key.
+  - `-r BASE_RESOURCE_UNIT` is an option. You can specify the RU of each database. The maximum RU in tables in the database will be set. If you don't specify RU of tables, the database RU will be set with this option. When you use transaction function, the RU of the coordinator table of Scalar DB is specified by this option. By default, it's 400.
+
+```console
+# For DynamoDB
+$ java -jar scalardb-schema-loader-<version>.jar --dynamo -u <AWS_ACCESS_KEY_ID> -p <AWS_ACCESS_SECRET_KEY> --region <REGION> -f schema.json [-r BASE_RESOURCE_UNIT]
+```
+  - `<REGION>` should be a string to specify an AWS region like `ap-northeast-1`.
+  - `-r` option is almost the same as Cosmos DB option. However, the unit means DynamoDB capacity unit. The read and write capacity units are set the same value.
+
+```console
+# For Cassandra
+$ java -jar scalardb-schema-loader-<version>.jar --cassandra -h <CASSANDRA_IP> [-P <CASSANDRA_PORT>] [-u <CASSANDRA_USER>] [-p <CASSANDRA_PASSWORD>] -f schema.json [-n <NETWORK_STRATEGY>] [-R <REPLICATION_FACTOR>]
+```
+  - If `-P <CASSANDRA_PORT>` is not supplied, it defaults to `9042`.
+  - If `-u <CASSANDRA_USER>` is not supplied, it defaults to `cassandra`.
+  - If `-p <CASSANDRA_PASSWORD>` is not supplied, it defaults to `cassandra`.
+  - `<NETWORK_STRATEGY>` should be `SimpleStrategy` or `NetworkTopologyStrategy`
+
+```console
+# For a JDBC database
+$ java -jar scalardb-schema-loader-<version>.jar --jdbc -j <JDBC URL> -u <USER> -p <PASSWORD> -f schema.json
+```
+
+### Delete tables
+
+For using config file (Sample config file can be found [here](../conf/database.properties)):
+```console
+$ java -jar scalardb-schema-loader-<version>.jar --config <PATH_TO_CONFIG_FILE> -f schema.json [--coordinator] -D 
+```
+  - if `--coordinator` is specified, the coordinator table will be deleted.
+  
+For using CLI arguments fully for configuration (Deprecated. Please use the command using a config file instead):
+```console
+# For Cosmos DB
+$ java -jar scalardb-schema-loader-<version>.jar --cosmos -h <COSMOS_DB_ACCOUNT_URI> -p <COSMOS_DB_KEY> -f schema.json -D
+```
+
+```console
+# For DynamoDB
+$ java -jar scalardb-schema-loader-<version>.jar --dynamo -u <AWS_ACCESS_KEY_ID> -p <AWS_ACCESS_SECRET_KEY> --region <REGION> -f schema.json -D
+```
+
+```console
+# For Cassandra
+$ java -jar scalardb-schema-loader-<version>.jar --cassandra -h <CASSANDRA_IP> [-P <CASSANDRA_PORT>] [-u <CASSNDRA_USER>] [-p <CASSANDRA_PASSWORD>] -f schema.json -D
+```
+
+```console
+# For a JDBC database
+$ java -jar scalardb-schema-loader-<version>.jar --jdbc -j <JDBC URL> -u <USER> -p <PASSWORD> -f schema.json -D
+```
+
+### Sample schema file
+```json
+{
+  "sample_db.sample_table": {
+    "transaction": false,
+    "partition-key": [
+      "c1"
+    ],
+    "clustering-key": [
+      "c4 ASC",
+      "c6 DESC"
+    ],
+    "columns": {
+      "c1": "INT",
+      "c2": "TEXT",
+      "c3": "BLOB",
+      "c4": "INT",
+      "c5": "BOOLEAN",
+      "c6": "INT"
+    },
+    "secondary-index": [
+      "c2",
+      "c4"
+    ]
+  },
+
+  "sample_db.sample_table1": {
+    "transaction": true,
+    "partition-key": [
+      "c1"
+    ],
+    "clustering-key": [
+      "c4"
+    ],
+    "columns": {
+      "c1": "INT",
+      "c2": "TEXT",
+      "c3": "INT",
+      "c4": "INT",
+      "c5": "BOOLEAN"
+    }
+  },
+
+  "sample_db.sample_table2": {
+    "transaction": false,
+    "partition-key": [
+      "c1"
+    ],
+    "clustering-key": [
+      "c4",
+      "c3"
+    ],
+    "columns": {
+      "c1": "INT",
+      "c2": "TEXT",
+      "c3": "INT",
+      "c4": "INT",
+      "c5": "BOOLEAN"
+    }
+  }
+}
+```
+
+You can also specify database/storage-specific options in the table definition as follows:
+```json
+{
+  "sample_db.sample_table3": {
+    "partition-key": [
+      "c1"
+    ],
+    "columns": {
+      "c1": "INT",
+      "c2": "TEXT",
+      "c3": "BLOB"
+    },
+    "compaction-strategy": "LCS",
+    "ru": 5000
+  }
+}
+```
+
+The database/storage-specific options you can specify are as follows:
+
+For Cassandra:
+- `compaction-strategy`, a compaction strategy. It should be `STCS` (SizeTieredCompaction), `LCS` (LeveledCompactionStrategy) or `TWCS` (TimeWindowCompactionStrategy).
+
+For DynamoDB and Cosmos DB:
+- `ru`, a request unit. Please see [RU](#RU) for the details.
+
+## Scaling Performance
+
+### RU
+
+You can scale the throughput of Cosmos DB and DynamoDB by specifying `--ru` option (which applies to all the tables) or `ru` parameter for each table. The default values are `400` for Cosmos DB and `10` for DynamoDB respectively, which are set without `--ru` option.
+
+Note that the schema loader abstracts [Request Unit](https://docs.microsoft.com/azure/cosmos-db/request-units) of Cosmos DB and [Capacity Unit](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual) of DynamoDB with `RU`.
+So, please set an appropriate value depending on the database implementations. Please also note that the schema loader sets the same value to both Read Capacity Unit and Write Capacity Unit for DynamoDB.
+
+### Auto-scaling
+
+By default, the schema loader enables auto-scaling of RU for all tables: RU is scaled in or out between 10% and 100% of a specified RU depending on a workload. For example, if you specify `-r 10000`, RU of each table is scaled in or out between 1000 and 10000. Note that auto-scaling of Cosmos DB is enabled only when you set more than or equal to 4000 RU.
+
+## Data type mapping for JDBC databases
+
+When creating tables for a JDBC database with this tool, Scalar DB data types are converted to RDB-specific data types as shown below.
+
+| ScalarDB | MySQL | PostgreSQL | Oracle | SQL Server |
+| ---- | ---- |  ---- |  ---- |  ---- | 
+| INT | INT | INT | INT | INT |
+| BIGINT | BIGINT | BIGINT | NUMBER(19) | BIGINT |
+| TEXT | LONGTEXT | TEXT | VARCHAR2(4000) | VARCHAR(8000) |
+| FLOAT | DOUBLE | FLOAT | BINARY_FLOAT | FLOAT(24) |
+| DOUBLE | DOUBLE | DOUBLE PRECISION | BINARY_DOUBLE | FLOAT |
+| BOOLEAN | BOOLEAN | BOOLEAN | NUMBER(1) | BIT |
+| BLOB | LONGBLOB | BYTEA | BLOB | VARBINARY(8000) |
+
+However, the following types are converted differently when they are used as a primary key or a secondary index key due to the limitations of RDB data types.
+
+| ScalarDB | MySQL | PostgreSQL | Oracle | SQL Server |
+| ---- | ---- |  ---- |  ---- |  ---- |
+| TEXT | VARCHAR(64) | VARCHAR(10485760) | VARCHAR2(64) | |
+| BLOB | VARBINARY(64) | | RAW(64) | |
+
+If this data type mapping doesn't match your application, please alter the tables to change the data types after creating them with this tool.
+
+## Using Schema Loader in your program
+You can check the version of `schema-loader` from [maven central repository](https://mvnrepository.com/artifact/com.scalar-labs/scalardb-schema-loader).
+For example in Gradle, you can add the following dependency to your build.gradle. Please replace the `<version>` with the version you want to use.
+```gradle
+dependencies {
+    implementation group: 'com.scalar-labs', name: 'scalardb-schema-loader', version: '<version>'
+}
+```
+
+### Create and delete tables
+You can create and delete tables that are defined in the schema using SchemaLoader by simply passing Scalar DB configuration file, schema, and additional options if needed as shown below.
+
+```java
+public class SchemaLoaderSample {
+  public static int main(String... args) throws SchemaLoaderException {
+    Path configFilePath = Paths.get("database.properties");
+    Path schemaFilePath = Paths.get("sample_schema.json");
+    boolean createCoordinatorTable = true; // whether creating the coordinator table or not
+    boolean deleteCoordinatorTable = true; // whether deleting the coordinator table or not
+
+    Map<String, String> options = new HashMap<>();
+
+    options.put(
+        CassandraAdmin.REPLICATION_STRATEGY, ReplicationStrategy.SIMPLE_STRATEGY.toString());
+    options.put(CassandraAdmin.COMPACTION_STRATEGY, CompactionStrategy.LCS.toString());
+    options.put(CassandraAdmin.REPLICATION_FACTOR, "1");
+
+    options.put(DynamoAdmin.REQUEST_UNIT, "1");
+    options.put(DynamoAdmin.NO_SCALING, "true");
+    options.put(DynamoAdmin.NO_BACKUP, "true");
+
+    // Create tables
+    SchemaLoader.load(configFilePath, schemaFilePath, options, createCoordinatorTable);
+
+    // Delete tables
+    SchemaLoader.unload(configFilePath, schemaFilePath, deleteCoordinatorTable);
+
+    return 0;
+  }
+}
+```
+
+You can also create and delete a schema by passing a serialized schema JSON string (the raw text of a schema file).
+```java
+// Create tables
+SchemaLoader.load(configFilePath, serializedSchemaJson, options, createCoordinatorTable);
+
+// Delete tables
+SchemaLoader.unload(configFilePath, serializedSchemaJson, deleteCoordinatorTable);
+```
+
+For Scalar DB configuration, a `Properties` object can be used as well.
+```java
+// Create tables
+SchemaLoader.load(properties, serializedSchemaJson, options, createCoordinatorTable);
+
+// Delete tables
+SchemaLoader.unload(properties, serializedSchemaJson, deleteCoordinatorTable);
+```

--- a/docs/3.5/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.5/scalardb-samples/microservice-transaction-sample/README.md
@@ -99,7 +99,7 @@ $ cd scalardb-samples/microservice-transaction-sample
 
 ### Start Cassandra and MySQL
 
-Cassandra and MySQL are already configured for the sample application, as shown in [`database.properties`](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
+Cassandra and MySQL are already configured for the sample application, as shown in [`database-cassandra.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-cassandra.properties) and [`database-mysql.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-mysql.properties), respectively. For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
 
 To start Cassandra and MySQL, which are included in the Docker container for the sample application, run the following command:
 

--- a/docs/3.5/schema-loader.md
+++ b/docs/3.5/schema-loader.md
@@ -192,7 +192,7 @@ To create namespaces and tables by using a properties file, run the following co
 $ java -jar scalardb-schema-loader-<VERSION>.jar --config <PATH_TO_SCALARDB_PROPERTIES_FILE> -f <PATH_TO_SCHEMA_FILE> [--coordinator]
 ```
 
-If `--coordinator` is specified, a [Coordinator table](api-guide.md#specify-operations-for-the-coordinator-table) will be created.
+If `--coordinator` is specified, a Coordinator table will be created.
 
 {% capture notice--info %}
 **Note**
@@ -373,7 +373,7 @@ The schema has table definitions that include `columns`, `partition-key`, `clust
 - The `secondary-index` field defines which columns are indexed.
 - The `transaction` field indicates whether the table is for transactions or not.
   - If you set the `transaction` field to `true` or don't specify the `transaction` field, this tool creates a table with transaction metadata if needed.
-  - If you set the `transaction` field to `false`, this tool creates a table without any transaction metadata (that is, for a table with [Storage API](storage-abstraction.md)).
+  - If you set the `transaction` field to `false`, this tool creates a table without any transaction metadata (that is, for a table with Storage API).
 
 You can also specify database or storage-specific options in the table definition as follows:
 

--- a/docs/3.6/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.6/scalardb-samples/microservice-transaction-sample/README.md
@@ -101,7 +101,7 @@ $ cd scalardb-samples/microservice-transaction-sample
 
 ### Start Cassandra and MySQL
 
-Cassandra and MySQL are already configured for the sample application, as shown in [`database.properties`](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
+Cassandra and MySQL are already configured for the sample application, as shown in [`database-cassandra.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-cassandra.properties) and [`database-mysql.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-mysql.properties), respectively. For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
 
 To start Cassandra and MySQL, which are included in the Docker container for the sample application, run the following command:
 

--- a/docs/3.7/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.7/scalardb-samples/microservice-transaction-sample/README.md
@@ -99,7 +99,7 @@ $ cd scalardb-samples/microservice-transaction-sample
 
 ### Start Cassandra and MySQL
 
-Cassandra and MySQL are already configured for the sample application, as shown in [`database.properties`](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
+Cassandra and MySQL are already configured for the sample application, as shown in [`database-cassandra.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-cassandra.properties) and [`database-mysql.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-mysql.properties), respectively. For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
 
 To start Cassandra and MySQL, which are included in the Docker container for the sample application, run the following command:
 

--- a/docs/3.8/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.8/scalardb-samples/microservice-transaction-sample/README.md
@@ -108,7 +108,7 @@ $ cd scalardb-samples/microservice-transaction-sample
 
 ### Start Cassandra and MySQL
 
-Cassandra and MySQL are already configured for the sample application, as shown in [`database.properties`](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
+Cassandra and MySQL are already configured for the sample application, as shown in [`database-cassandra.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-cassandra.properties) and [`database-mysql.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-mysql.properties), respectively. For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
 
 To start Cassandra and MySQL, which are included in the Docker container for the sample application, run the following command:
 

--- a/docs/3.9/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.9/scalardb-samples/microservice-transaction-sample/README.md
@@ -108,7 +108,7 @@ $ cd scalardb-samples/microservice-transaction-sample
 
 ### Start Cassandra and MySQL
 
-Cassandra and MySQL are already configured for the sample application, as shown in [`database.properties`](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
+Cassandra and MySQL are already configured for the sample application, as shown in [`database-cassandra.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-cassandra.properties) and [`database-mysql.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-mysql.properties), respectively. For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
 
 To start Cassandra and MySQL, which are included in the Docker container for the sample application, run the following command:
 

--- a/docs/latest/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/latest/scalardb-samples/microservice-transaction-sample/README.md
@@ -108,7 +108,7 @@ $ cd scalardb-samples/microservice-transaction-sample
 
 ### Start Cassandra and MySQL
 
-Cassandra and MySQL are already configured for the sample application, as shown in [`database.properties`](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
+Cassandra and MySQL are already configured for the sample application, as shown in [`database-cassandra.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-cassandra.properties) and [`database-mysql.properties`](https://github.com/scalar-labs/scalardb-samples/blob/main/microservice-transaction-sample/database-mysql.properties), respectively. For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
 
 To start Cassandra and MySQL, which are included in the Docker container for the sample application, run the following command:
 


### PR DESCRIPTION
## Description

This PR fixes broken links in ScalarDB docs and in Scalar Kubernetes docs for ScalarDB versions that are no longer supported.

> [!IMPORTANT]
>
> The fix for broken links for the ScalarDB docs in this PR is an interim fix. The links need to be fixed in the centralized ScalarDB docs repository after migration.

## Related issues and/or PRs

N/A

## Changes made

- Fixed broken links.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A