### PR TITLE
Add release notes for patch versions

### DIFF
--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -2,6 +2,59 @@
 
 This page includes a list of release notes for ScalarDB 3.12.
 
+## v3.12.3
+
+**Release date:** July 3, 2024
+
+### Summary
+
+This release includes several improvements, bug fixes, and vulnerability fixes.
+
+### Community edition
+
+#### Improvements
+
+- Refactored scan with filtering. ([#1715](https://github.com/scalar-labs/scalardb/pull/1715))
+- Changed the hard-coded password for the Oracle user to a more secure one in the JDBC adapter. ([#1765](https://github.com/scalar-labs/scalardb/pull/1765))
+- Update base image of container image. This update fixes an OOM issue on a Kubernetes with cgroup v2 environment. In the previous versions, if you use a Kubernetes cluster with cgroup v2, you might face an OOM-killed issue. ([#1826](https://github.com/scalar-labs/scalardb/pull/1826))
+
+#### Bug fixes
+
+- Fixed a bug where `NullPointerException` occurs during the `EXTRA_READ` validation when scanning records in a transaction, but some of them are deleted by other transactions. ([#1624](https://github.com/scalar-labs/scalardb/pull/1624))
+- Fixed a bug where lazy recovery was not executed for the implicit pre-read of put and delete operations. ([#1681](https://github.com/scalar-labs/scalardb/pull/1681))
+- Fixed a bug where users could see inconsistent results when scanning records by an index key after putting the related records in Consensus Commit transactions. ([#1727](https://github.com/scalar-labs/scalardb/pull/1727))
+- Upgraded `grpc_health_probe` to fix security issues. [CVE-2024-24790](https://github.com/advisories/GHSA-49gw-vxvf-fc2g "CVE-2024-24790"), [CVE-2023-45283](https://github.com/advisories/GHSA-vvjp-q62m-2vph "CVE-2023-45283"), and [CVE-2023-45288](https://github.com/advisories/GHSA-4v7x-pqxf-cx7m "CVE-2023-45288") ([#1980](https://github.com/scalar-labs/scalardb/pull/1980))
+- Fixed snapshot management issues. ([#1976](https://github.com/scalar-labs/scalardb/pull/1976))
+- Fix a bug of the import-table feature that it could access tables in other namespace that have the same table name when using MySQL storage. For example, in the following situation, the metadata of the columns `pk_unexpected` and `col_unexpected` of `ns2.tbl1` are handled and the import-table feature fails due to unsupported data types. ([#2001](https://github.com/scalar-labs/scalardb/pull/2001))
+
+### Enterprise edition
+
+#### Improvements
+
+##### ScalarDB Cluster
+
+- Update base image of container image. This update fixes an OOM issue on a Kubernetes with cgroup v2 environment. In the previous versions, if you use a Kubernetes cluster with cgroup v2, you might face an OOM-killed issue.
+
+##### ScalarDB GraphQL
+
+- Update base image of container image. This update fixes an OOM issue on a Kubernetes with cgroup v2 environment. In the previous versions, if you use a Kubernetes cluster with cgroup v2, you might face an OOM-killed issue.
+
+##### ScalarDB SQL
+
+- Changed the packages for `ConditionSetBuilder` and `AndConditionSet`.
+- Update base image of container image. This update fixes an OOM issue on a Kubernetes with cgroup v2 environment. In the previous versions, if you use a Kubernetes cluster with cgroup v2, you might face an OOM-killed issue.
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Upgraded `grpc_health_probe` to fix security issues. [CVE-2024-24790](https://github.com/advisories/GHSA-49gw-vxvf-fc2g "CVE-2024-24790"), [CVE-2023-45283](https://github.com/advisories/GHSA-vvjp-q62m-2vph "CVE-2023-45283"), and [CVE-2023-45288](https://github.com/advisories/GHSA-4v7x-pqxf-cx7m "CVE-2023-45288")
+
+##### ScalarDB SQL
+
+- Fixed a bug where incorrect results are returned when executing SELECT queries with the same column names.
+- Upgraded `grpc_health_probe` to fix security issues. [CVE-2024-24790](https://github.com/advisories/GHSA-49gw-vxvf-fc2g "CVE-2024-24790"), [CVE-2023-45283](https://github.com/advisories/GHSA-vvjp-q62m-2vph "CVE-2023-45283"), and [CVE-2023-45288](https://github.com/advisories/GHSA-4v7x-pqxf-cx7m "CVE-2023-45288")
+
 ## v3.12.2
 
 **Release date:** April 1, 2024

--- a/versioned_docs/version-3.10/releases/release-notes.mdx
+++ b/versioned_docs/version-3.10/releases/release-notes.mdx
@@ -2,6 +2,55 @@
 
 This page includes a list of release notes for ScalarDB 3.10.
 
+## v3.10.5
+
+**Release date:** July 3, 2024
+
+### Summary
+
+This release includes several improvements, bug fixes, and vulnerability fixes.
+
+### Community edition
+
+#### Improvements
+
+- Refactored scan with filtering. ([#1715](https://github.com/scalar-labs/scalardb/pull/1715))
+- Changed the hard-coded password for the Oracle user to a more secure one in the JDBC adapter. ([#1765](https://github.com/scalar-labs/scalardb/pull/1765))
+- Update base image of container image. This update fixes an OOM issue on a Kubernetes with cgroup v2 environment. In the previous versions, if you use a Kubernetes cluster with cgroup v2, you might face an OOM-killed issue. ([#1826](https://github.com/scalar-labs/scalardb/pull/1826))
+
+#### Bug fixes
+
+- Fixed a bug where `NullPointerException` occurs during the `EXTRA_READ` validation when scanning records in a transaction, but some of them are deleted by other transactions. ([#1624](https://github.com/scalar-labs/scalardb/pull/1624))
+- Fixed a bug where users could see inconsistent results when scanning records by an index key after putting the related records in Consensus Commit transactions. ([#1727](https://github.com/scalar-labs/scalardb/pull/1727))
+- Upgraded `grpc_health_probe` to fix security issues. [CVE-2024-24790](https://github.com/advisories/GHSA-49gw-vxvf-fc2g "CVE-2024-24790"), [CVE-2023-45283](https://github.com/advisories/GHSA-vvjp-q62m-2vph "CVE-2023-45283"), and [CVE-2023-45288](https://github.com/advisories/GHSA-4v7x-pqxf-cx7m "CVE-2023-45288") ([#1980](https://github.com/scalar-labs/scalardb/pull/1980))
+- Fixed snapshot management issues. ([#1976](https://github.com/scalar-labs/scalardb/pull/1976))
+
+### Enterprise edition
+
+#### Improvements
+
+##### ScalarDB Cluster
+
+- Update base image of container image. This update fixes an OOM issue on a Kubernetes with cgroup v2 environment. In the previous versions, if you use a Kubernetes cluster with cgroup v2, you might face an OOM-killed issue.
+
+##### ScalarDB GraphQL
+
+- Update base image of container image. This update fixes an OOM issue on a Kubernetes with cgroup v2 environment. In the previous versions, if you use a Kubernetes cluster with cgroup v2, you might face an OOM-killed issue.
+
+##### ScalarDB SQL
+
+- Update base image of container image. This update fixes an OOM issue on a Kubernetes with cgroup v2 environment. In the previous versions, if you use a Kubernetes cluster with cgroup v2, you might face an OOM-killed issue.
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Upgraded `grpc_health_probe` to fix security issues. [CVE-2024-24790](https://github.com/advisories/GHSA-49gw-vxvf-fc2g "CVE-2024-24790"), [CVE-2023-45283](https://github.com/advisories/GHSA-vvjp-q62m-2vph "CVE-2023-45283"), and [CVE-2023-45288](https://github.com/advisories/GHSA-4v7x-pqxf-cx7m "CVE-2023-45288")
+
+##### ScalarDB SQL
+
+- Upgraded `grpc_health_probe` to fix security issues. [CVE-2024-24790](https://github.com/advisories/GHSA-49gw-vxvf-fc2g "CVE-2024-24790"), [CVE-2023-45283](https://github.com/advisories/GHSA-vvjp-q62m-2vph "CVE-2023-45283"), and [CVE-2023-45288](https://github.com/advisories/GHSA-4v7x-pqxf-cx7m "CVE-2023-45288")
+
 ## v3.10.4
 
 **Release date:** April 1, 2024

--- a/versioned_docs/version-3.11/releases/release-notes.mdx
+++ b/versioned_docs/version-3.11/releases/release-notes.mdx
@@ -2,6 +2,59 @@
 
 This page includes a list of release notes for ScalarDB 3.11.
 
+## v3.11.3
+
+**Release date:** July 3, 2024
+
+### Summary
+
+This release includes several improvements, bug fixes, and vulnerability fixes.
+
+### Community edition
+
+#### Improvements
+
+- Refactored scan with filtering. ([#1715](https://github.com/scalar-labs/scalardb/pull/1715))
+- Changed the hard-coded password for the Oracle user to a more secure one in the JDBC adapter. ([#1765](https://github.com/scalar-labs/scalardb/pull/1765))
+- Update base image of container image. This update fixes an OOM issue on a Kubernetes with cgroup v2 environment. In the previous versions, if you use a Kubernetes cluster with cgroup v2, you might face an OOM-killed issue. ([#1826](https://github.com/scalar-labs/scalardb/pull/1826))
+
+#### Bug fixes
+
+- Fixed a bug where `NullPointerException` occurs during the `EXTRA_READ` validation when scanning records in a transaction, but some of them are deleted by other transactions. ([#1624](https://github.com/scalar-labs/scalardb/pull/1624))
+- Fixed a bug where lazy recovery was not executed for the implicit pre-read of put and delete operations. ([#1681](https://github.com/scalar-labs/scalardb/pull/1681))
+- Fixed a bug where users could see inconsistent results when scanning records by an index key after putting the related records in Consensus Commit transactions. ([#1727](https://github.com/scalar-labs/scalardb/pull/1727))
+- Upgraded `grpc_health_probe` to fix security issues. [CVE-2024-24790](https://github.com/advisories/GHSA-49gw-vxvf-fc2g "CVE-2024-24790"), [CVE-2023-45283](https://github.com/advisories/GHSA-vvjp-q62m-2vph "CVE-2023-45283"), and [CVE-2023-45288](https://github.com/advisories/GHSA-4v7x-pqxf-cx7m "CVE-2023-45288") ([#1980](https://github.com/scalar-labs/scalardb/pull/1980))
+- Fixed snapshot management issues. ([#1976](https://github.com/scalar-labs/scalardb/pull/1976))
+- Fix a bug of the import-table feature that it could access tables in other namespace that have the same table name when using MySQL storage. For example, in the following situation, the metadata of the columns `pk_unexpected` and `col_unexpected` of `ns2.tbl1` are handled and the import-table feature fails due to unsupported data types. ([#2001](https://github.com/scalar-labs/scalardb/pull/2001))
+
+### Enterprise edition
+
+#### Improvements
+
+##### ScalarDB Cluster
+
+- Update base image of container image. This update fixes an OOM issue on a Kubernetes with cgroup v2 environment. In the previous versions, if you use a Kubernetes cluster with cgroup v2, you might face an OOM-killed issue.
+
+##### ScalarDB GraphQL
+
+- Update base image of container image. This update fixes an OOM issue on a Kubernetes with cgroup v2 environment. In the previous versions, if you use a Kubernetes cluster with cgroup v2, you might face an OOM-killed issue.
+
+##### ScalarDB SQL
+
+- Changed the packages for `ConditionSetBuilder` and `AndConditionSet`.
+- Update base image of container image. This update fixes an OOM issue on a Kubernetes with cgroup v2 environment. In the previous versions, if you use a Kubernetes cluster with cgroup v2, you might face an OOM-killed issue.
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Upgraded `grpc_health_probe` to fix security issues. [CVE-2024-24790](https://github.com/advisories/GHSA-49gw-vxvf-fc2g "CVE-2024-24790"), [CVE-2023-45283](https://github.com/advisories/GHSA-vvjp-q62m-2vph "CVE-2023-45283"), and [CVE-2023-45288](https://github.com/advisories/GHSA-4v7x-pqxf-cx7m "CVE-2023-45288")
+
+##### ScalarDB SQL
+
+- Fixed a bug where incorrect results are returned when executing SELECT queries with the same column names.
+- Upgraded `grpc_health_probe` to fix security issues. [CVE-2024-24790](https://github.com/advisories/GHSA-49gw-vxvf-fc2g "CVE-2024-24790"), [CVE-2023-45283](https://github.com/advisories/GHSA-vvjp-q62m-2vph "CVE-2023-45283"), and [CVE-2023-45288](https://github.com/advisories/GHSA-4v7x-pqxf-cx7m "CVE-2023-45288")
+
 ## v3.11.2
 
 **Release date:** April 1, 2024

--- a/versioned_docs/version-3.8/releases/release-notes.mdx
+++ b/versioned_docs/version-3.8/releases/release-notes.mdx
@@ -2,6 +2,24 @@
 
 This page includes a list of release notes for ScalarDB 3.8.
 
+## v3.8.7
+
+**Release date:** June 28, 2024
+
+### Summary
+
+This release includes several improvements, bug fixes, and vulnerability fixes.
+
+### Improvements
+
+- Changed the hard-coded password for the Oracle user to a more secure one in the JDBC adapter. ([#1765](https://github.com/scalar-labs/scalardb/pull/1765))
+- Update base image of container image. This update fixes an OOM issue on a Kubernetes with cgroup v2 environment. In the previous versions, if you use a Kubernetes cluster with cgroup v2, you might face an OOM-killed issue. ([#1826](https://github.com/scalar-labs/scalardb/pull/1826))
+
+### Bug fixes
+
+- Fixed a bug where `NullPointerException` occurs during the `EXTRA_READ` validation when scanning records in a transaction, but some of them are deleted by other transactions. ([#1624](https://github.com/scalar-labs/scalardb/pull/1624))
+- Upgraded `grpc_health_probe` to fix security issues. [CVE-2024-24790](https://github.com/advisories/GHSA-49gw-vxvf-fc2g "CVE-2024-24790"), [CVE-2023-45283](https://github.com/advisories/GHSA-vvjp-q62m-2vph "CVE-2023-45283"), and [CVE-2023-45288](https://github.com/advisories/GHSA-4v7x-pqxf-cx7m "CVE-2023-45288") ([#1980](https://github.com/scalar-labs/scalardb/pull/1980))
+
 ## v3.8.6
 
 **Release date:** April 1, 2024

--- a/versioned_docs/version-3.9/releases/release-notes.mdx
+++ b/versioned_docs/version-3.9/releases/release-notes.mdx
@@ -2,6 +2,52 @@
 
 This page includes a list of release notes for ScalarDB 3.9.
 
+## v3.9.6
+
+**Release date:** June 28, 2024
+
+### Summary
+
+This release includes several improvements, bug fixes, and vulnerability fixes.
+
+### Community edition
+
+#### Improvements
+
+- Changed the hard-coded password for the Oracle user to a more secure one in the JDBC adapter. ([#1765](https://github.com/scalar-labs/scalardb/pull/1765))
+- Update base image of container image. This update fixes an OOM issue on a Kubernetes with cgroup v2 environment. In the previous versions, if you use a Kubernetes cluster with cgroup v2, you might face an OOM-killed issue. ([#1826](https://github.com/scalar-labs/scalardb/pull/1826))
+
+#### Bug fixes
+
+- Fixed a bug where `NullPointerException` occurs during the `EXTRA_READ` validation when scanning records in a transaction, but some of them are deleted by other transactions. ([#1624](https://github.com/scalar-labs/scalardb/pull/1624))
+- Upgraded `grpc_health_probe` to fix security issues. [CVE-2024-24790](https://github.com/advisories/GHSA-49gw-vxvf-fc2g "CVE-2024-24790"), [CVE-2023-45283](https://github.com/advisories/GHSA-vvjp-q62m-2vph "CVE-2023-45283"), and [CVE-2023-45288](https://github.com/advisories/GHSA-4v7x-pqxf-cx7m "CVE-2023-45288") ([#1980](https://github.com/scalar-labs/scalardb/pull/1980))
+
+### Enterprise edition
+
+#### Improvements
+
+##### ScalarDB Cluster
+
+- Update base image of container image. This update fixes an OOM issue on a Kubernetes with cgroup v2 environment. In the previous versions, if you use a Kubernetes cluster with cgroup v2, you might face an OOM-killed issue.
+
+##### ScalarDB GraphQL
+
+- Update base image of container image. This update fixes an OOM issue on a Kubernetes with cgroup v2 environment. In the previous versions, if you use a Kubernetes cluster with cgroup v2, you might face an OOM-killed issue.
+
+##### ScalarDB SQL
+
+- Update base image of container image. This update fixes an OOM issue on a Kubernetes with cgroup v2 environment. In the previous versions, if you use a Kubernetes cluster with cgroup v2, you might face an OOM-killed issue.
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Upgraded `grpc_health_probe` to fix security issues. [CVE-2024-24790](https://github.com/advisories/GHSA-49gw-vxvf-fc2g "CVE-2024-24790"), [CVE-2023-45283](https://github.com/advisories/GHSA-vvjp-q62m-2vph "CVE-2023-45283"), and [CVE-2023-45288](https://github.com/advisories/GHSA-4v7x-pqxf-cx7m "CVE-2023-45288")
+
+##### ScalarDB SQL
+
+- Upgraded `grpc_health_probe` to fix security issues. [CVE-2024-24790](https://github.com/advisories/GHSA-49gw-vxvf-fc2g "CVE-2024-24790"), [CVE-2023-45283](https://github.com/advisories/GHSA-vvjp-q62m-2vph "CVE-2023-45283"), and [CVE-2023-45288](https://github.com/advisories/GHSA-4v7x-pqxf-cx7m "CVE-2023-45288")
+
 ## v3.9.5
 
 **Release date:** April 1, 2024


### PR DESCRIPTION
## Description

This PR adds release notes for ScalarDB patch versions `3.12.3`, `3.11.3`, `3.10.5`, `3.9.6`, and `3.8.7`.

## Related issues and/or PRs

N/A

## Changes made

- Added release notes for `3.12.3` to the  `3.12` release notes page.
- Added release notes for `3.11.3` to the  `3.11` release notes page.
- Added release notes for `3.10.5` to the  `3.10` release notes page.
- Added release notes for `3.9.6` to the  `3.9` release notes page.
- Added release notes for `3.8.7` to the  `3.8` release notes page.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A