### PR TITLE
Mark ScalarDB 3.7 as no longer supported 

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -97,9 +97,9 @@ const config = {
                 banner: 'none',
               },
               "3.7": {
-                label: '3.7',
+                label: '3.7 (unsupported)',
                 path: '3.7',
-                banner: 'none',
+                banner: 'unmaintained',
               },
               "3.6": {
                 label: '3.6 (unsupported)',


### PR DESCRIPTION
## Description

This PR marks ScalarDB 3.7 as no longer supported since Assistance Support ended on July 15, 2024.

## Related issues and/or PRs

N/A

## Changes made

- In `docusaurus.config.js`:
  - Added `(unsupported)` to 3.7 in the version selector.
  - Added the `unmaintained` banner, which automatically adds a banner to each page for version 3.7 that states the version is no longer supported.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A