### PR TITLE
Revise README to include note about deprecated repository and direct visitors to unified docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ScalarDB Community Documentation
 
-> **Note**
-> 
-> If you're looking for the documentation repository for the commercial version of ScalarDB, please see [scalar-labs/docs-scalardb](https://github.com/scalar-labs/docs-scalardb), which stores the documentation for [ScalarDB Enterprise Docs](https://scalardb.scalar-labs.com/docs).
-
-This repository contains documentation source files for the open-source version of ScalarDB. Please view this documentation at [ScalarDB Community Docs](https://scalardb-community.scalar-labs.com/docs).
+> [!IMPORTANT]
+>
+> The ScalarDB Community docs site repository is no longer maintained and will be archived in the near future since the docs now live on the [ScalarDB docs site](https://scalardb.scalar-labs.com/docs/).
+>
+> Currently, all pages from the ScalarDB Community docs site redirect visitors to the ScalarDB docs site. On those page are tags that show whether the contents apply to the Community edition, Enterprise edition, or Enterprise Premium edition of ScalarDB.
 
 ## Interested in using ScalarDB Enterprise?
 


### PR DESCRIPTION
## Description

This PR updates the README to mention that this repository is deprecated and to direct visitors to the unified [ScalarDB docs site](https://scalardb.scalar-labs.com/docs), which now includes docs for both Community and Enterprise editions.

## Related issues and/or PRs

N/A

## Changes made

- Revised README to mention that this repository is deprecated and to visit the unified ScalarDB docs site, which now includes docs for Community and Enterprise editions.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings. `N/A`
- [x] Any dependent changes in other PRs have been merged and published. `N/A`

## Additional notes (optional)

N/A