### PR TITLE
Add robots.txt to restrict crawling

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Description

This PR adds a **robots.txt** file to restrict search engines from crawling the docs site. We need to implement this because  pages to this old Community docs site still appear in search results. Although those links redirect visitors to the ScalarDB docs site, having links to the Community docs site in search results is confusing.

## Related issues and/or PRs

N/A

## Changes made

- Created a **robots.txt** file that tells web-crawling robots to not crawl the site.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A